### PR TITLE
During rerender try to reuse prop, style, transform nodes when possible

### DIFF
--- a/src/core/AnimatedNode.js
+++ b/src/core/AnimatedNode.js
@@ -46,6 +46,7 @@ export default class AnimatedNode {
   constructor(nodeConfig, inputNodes) {
     this.__nodeID = ++nodeCount;
     this.__nodeConfig = sanitizeConfig(nodeConfig);
+    this.__initialized = false;
     this.__inputNodes =
       inputNodes && inputNodes.filter(node => node instanceof AnimatedNode);
   }
@@ -93,15 +94,18 @@ export default class AnimatedNode {
   }
 
   __nativeInitialize() {
-    if (this.__nodeConfig) {
+    if (!this.__initialized) {
       ReanimatedModule.createNode(this.__nodeID, this.__nodeConfig);
-      this.__nodeConfig = undefined;
+      this.__initialized = true;
     }
   }
 
   __nativeTearDown() {
-    if (!this.__nodeConfig) {
+    if (this.__initialized) {
       ReanimatedModule.dropNode(this.__nodeID);
+      // TODO: the below line throws "object has been frozen" exception. Need to
+      // figure out the root cause of this issue and enable back that line
+      // this.__initialized = false;
     }
   }
 

--- a/src/core/AnimatedTransform.js
+++ b/src/core/AnimatedTransform.js
@@ -1,5 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 
+import deepEqual from 'fbjs/lib/areEqual';
+
 function sanitizeTransform(inputTransform) {
   const outputTransform = [];
   inputTransform.forEach(transform => {
@@ -34,12 +36,21 @@ function extractAnimatedParentNodes(transform) {
   return parents;
 }
 
-export default class AnimatedTransform extends AnimatedNode {
-  constructor(transform) {
+export function createOrReuseTransformNode(transform, oldNode) {
+  const config = sanitizeTransform(transform);
+  if (oldNode && deepEqual(config, oldNode._config)) {
+    return oldNode;
+  }
+  return new AnimatedTransform(transform, config);
+}
+
+class AnimatedTransform extends AnimatedNode {
+  constructor(transform, config) {
     super(
-      { type: 'transform', transform: sanitizeTransform(transform) },
+      { type: 'transform', transform: config },
       extractAnimatedParentNodes(transform)
     );
+    this._config = config;
     this._transform = transform;
   }
 

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -31,7 +31,6 @@ export default function createAnimatedComponent(Component) {
 
   class AnimatedComponent extends React.Component {
     _invokeAnimatedPropsCallbackOnMount = false;
-    _component = React.createRef();
 
     componentWillUnmount() {
       this._detachPropUpdater();
@@ -40,7 +39,7 @@ export default function createAnimatedComponent(Component) {
     }
 
     setNativeProps(props) {
-      this._component.current.setNativeProps(props);
+      this._component.setNativeProps(props);
     }
 
     componentWillMount() {
@@ -53,7 +52,7 @@ export default function createAnimatedComponent(Component) {
         this._animatedPropsCallback();
       }
 
-      this._propsAnimated.setNativeView(this._component.current);
+      this._propsAnimated.setNativeView(this._component);
       this._attachNativeEvents();
       this._attachPropUpdater();
     }
@@ -61,9 +60,9 @@ export default function createAnimatedComponent(Component) {
     _getEventViewRef() {
       // Make sure to get the scrollable node for components that implement
       // `ScrollResponder.Mixin`.
-      return this._component.current.getScrollableNode
-        ? this._component.current.getScrollableNode()
-        : this._component.current;
+      return this._component.getScrollableNode
+        ? this._component.getScrollableNode()
+        : this._component;
     }
 
     _attachNativeEvents() {
@@ -188,13 +187,19 @@ export default function createAnimatedComponent(Component) {
 
     render() {
       const props = this._propsAnimated.__getProps();
-      return <Component {...props} ref={this._component} collapsable={false} />;
+      return (
+        <Component
+          {...props}
+          ref={ref => (this._component = ref)}
+          collapsable={false}
+        />
+      );
     }
 
     // A third party library can use getNode()
     // to get the node reference of the decorated component
     getNode() {
-      return this._component.current;
+      return this._component;
     }
   }
 

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -6,8 +6,8 @@ import {
 } from 'react-native';
 import ViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes';
 
-import AnimatedProps from './core/AnimatedProps';
 import AnimatedEvent from './core/AnimatedEvent';
+import { createOrReusePropsNode } from './core/AnimatedProps';
 
 import invariant from 'fbjs/lib/invariant';
 
@@ -31,16 +31,7 @@ export default function createAnimatedComponent(Component) {
 
   class AnimatedComponent extends React.Component {
     _invokeAnimatedPropsCallbackOnMount = false;
-
-    _eventDetachers = [];
-
-    /* eslint-disable-next-line camelcase */
-    static __skipSetNativeProps_FOR_TESTS_ONLY = false;
-
-    constructor(props) {
-      super(props);
-      this._setComponentRef = this._setComponentRef.bind(this);
-    }
+    _component = React.createRef();
 
     componentWillUnmount() {
       this._detachPropUpdater();
@@ -49,7 +40,7 @@ export default function createAnimatedComponent(Component) {
     }
 
     setNativeProps(props) {
-      this._component.setNativeProps(props);
+      this._component.current.setNativeProps(props);
     }
 
     componentWillMount() {
@@ -62,32 +53,70 @@ export default function createAnimatedComponent(Component) {
         this._animatedPropsCallback();
       }
 
-      this._propsAnimated.setNativeView(this._component);
+      this._propsAnimated.setNativeView(this._component.current);
       this._attachNativeEvents();
       this._attachPropUpdater();
     }
 
-    _attachNativeEvents() {
+    _getEventViewRef() {
       // Make sure to get the scrollable node for components that implement
       // `ScrollResponder.Mixin`.
-      const scrollableNode = this._component.getScrollableNode
-        ? this._component.getScrollableNode()
-        : this._component;
+      return this._component.current.getScrollableNode
+        ? this._component.current.getScrollableNode()
+        : this._component.current;
+    }
+
+    _attachNativeEvents() {
+      const node = this._getEventViewRef();
 
       for (const key in this.props) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
-          prop.attachEvent(scrollableNode, key);
-          this._eventDetachers.push(() =>
-            prop.detachEvent(scrollableNode, key)
-          );
+          prop.attachEvent(node, key);
         }
       }
     }
 
     _detachNativeEvents() {
-      this._eventDetachers.forEach(remove => remove());
-      this._eventDetachers = [];
+      const node = this._getEventViewRef();
+
+      for (const key in this.props) {
+        const prop = this.props[key];
+        if (prop instanceof AnimatedEvent) {
+          prop.detachEvent(node, key);
+        }
+      }
+    }
+
+    _reattachNativeEvents(prevProps) {
+      const node = this._getEventViewRef();
+      const attached = new Set();
+      const nextEvts = new Set();
+      for (const key in this.props) {
+        const prop = this.props[key];
+        if (prop instanceof AnimatedEvent) {
+          nextEvts.add(prop);
+        }
+      }
+      for (const key in prevProps) {
+        const prop = this.props[key];
+        if (prop instanceof AnimatedEvent) {
+          if (!nextEvts.has(prop)) {
+            // event was in prev props but not in current props, we detach
+            prop.detachEvent(node, key);
+          } else {
+            // event was in prev and is still in current props
+            attached.add(prop);
+          }
+        }
+      }
+      for (const key in this.props) {
+        const prop = this.props[key];
+        if (prop instanceof AnimatedEvent && !attached.has(prop)) {
+          // not yet attached
+          prop.attachEvent(node, key);
+        }
+      }
     }
 
     // The system is best designed when setNativeProps is implemented. It is
@@ -103,10 +132,7 @@ export default function createAnimatedComponent(Component) {
         // React may throw away uncommitted work in async mode,
         // So a deferred call won't always be invoked.
         this._invokeAnimatedPropsCallbackOnMount = true;
-      } else if (
-        AnimatedComponent.__skipSetNativeProps_FOR_TESTS_ONLY ||
-        typeof this._component.setNativeProps !== 'function'
-      ) {
+      } else if (typeof this._component.setNativeProps !== 'function') {
         this.forceUpdate();
       } else {
         this._component.setNativeProps(this._propsAnimated.__getValue());
@@ -116,20 +142,23 @@ export default function createAnimatedComponent(Component) {
     _attachProps(nextProps) {
       const oldPropsAnimated = this._propsAnimated;
 
-      this._propsAnimated = new AnimatedProps(
+      this._propsAnimated = createOrReusePropsNode(
         nextProps,
-        this._animatedPropsCallback
+        this._animatedPropsCallback,
+        oldPropsAnimated
       );
-
-      // When you call detach, it removes the element from the parent list
-      // of children. If it goes to 0, then the parent also detaches itself
-      // and so on.
-      // An optimization is to attach the new elements and THEN detach the old
-      // ones instead of detaching and THEN attaching.
-      // This way the intermediate state isn't to go to 0 and trigger
-      // this expensive recursive detaching to then re-attach everything on
-      // the very next operation.
-      oldPropsAnimated && oldPropsAnimated.__detach();
+      // If prop node has been reused we don't need to call into "__detach"
+      if (oldPropsAnimated !== this._propsAnimated) {
+        // When you call detach, it removes the element from the parent list
+        // of children. If it goes to 0, then the parent also detaches itself
+        // and so on.
+        // An optimization is to attach the new elements and THEN detach the old
+        // ones instead of detaching and THEN attaching.
+        // This way the intermediate state isn't to go to 0 and trigger
+        // this expensive recursive detaching to then re-attach everything on
+        // the very next operation.
+        oldPropsAnimated && oldPropsAnimated.__detach();
+      }
     }
 
     _updateFromNative(props) {
@@ -152,36 +181,20 @@ export default function createAnimatedComponent(Component) {
       }
     }
 
-    componentWillReceiveProps(newProps) {
-      this._attachProps(newProps);
-    }
-
     componentDidUpdate(prevProps) {
-      if (this._component !== this._prevComponent) {
-        this._propsAnimated.setNativeView(this._component);
-      }
-      if (this._component !== this._prevComponent || prevProps !== this.props) {
-        this._detachNativeEvents();
-        this._attachNativeEvents();
-      }
+      this._attachProps(this.props);
+      this._reattachNativeEvents(prevProps);
     }
 
     render() {
       const props = this._propsAnimated.__getProps();
-      return (
-        <Component {...props} ref={this._setComponentRef} collapsable={false} />
-      );
-    }
-
-    _setComponentRef(c) {
-      this._prevComponent = this._component;
-      this._component = c;
+      return <Component {...props} ref={this._component} collapsable={false} />;
     }
 
     // A third party library can use getNode()
     // to get the node reference of the decorated component
     getNode() {
-      return this._component;
+      return this._component.current;
     }
   }
 


### PR DESCRIPTION
When reanimated component gets re-rendered we used to create new Prop node which in turn created Style and Transform node if present.
This turns out to be a huge waste of resources as new nodes would generate additional bridge traffic while they often represent the same prop mapping.

We now extract prop, style and transform node configuration which uniquely represents node behavior and try to match that with node used previously. If config matches we reuse the node instead of creating a new one.

This also fixes #13 