### PR TITLE
Fix issue with transform config being shared between all nodes

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/TransformNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/TransformNode.java
@@ -61,7 +61,7 @@ public class TransformNode extends Node<WritableArray> {
     return configs;
   }
 
-  private static List<TransformConfig> mTransforms;
+  private List<TransformConfig> mTransforms;
 
   public TransformNode(int nodeID, ReadableMap config, NodesManager nodesManager) {
     super(nodeID, config, nodesManager);


### PR DESCRIPTION
This "static" keyword slipped in by accident (perhaps when refactoring processTransforms to be a static method). It was causing all transform node configs to be overwritten by the most recent one and hence preventing multiple installed animated views from functioning on Android.
