### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Returns `1` if the given node evaluates to a "defined" value (that is to somethi
 ### `not`
 
 ```js
-defined(node)
+not(node)
 ```
 
 Returns `1` if the given node evaluates to a "falsy" value and `0` otherwise.
@@ -491,7 +491,7 @@ The `frameTime` node will also get updated and represents the progress of animat
 spring(clock, { finished, position, velocity, time }, { damping, mass, stiffness, overshootClamping, restSpeedThreshold, restDisplacementThreshold, toValue })
 ```
 
-When evaluated updates `position` and `velocity` nodes by running a single step of spring based animation. Check the original Animated API docs to lear about the config parameters like `damping`, `mass`, `stiffness`, `overshootClamping`, `restSpeedThreshold` and `restDisplacementThreshold`. The `finished` state updates to `1` when the `position` reaches the destination set by `toValue`. The `time` state variable also updates when the node evaluates and it represents the clock value at the time when the node got evaluated for the last time. It is expected that `time` variable is reset before spring animation can be restarted.
+When evaluated updates `position` and `velocity` nodes by running a single step of spring based animation. Check the original Animated API docs to learn about the config parameters like `damping`, `mass`, `stiffness`, `overshootClamping`, `restSpeedThreshold` and `restDisplacementThreshold`. The `finished` state updates to `1` when the `position` reaches the destination set by `toValue`. The `time` state variable also updates when the node evaluates and it represents the clock value at the time when the node got evaluated for the last time. It is expected that `time` variable is reset before spring animation can be restarted.
 
 ## Running animations
 


### PR DESCRIPTION
`defined` -> `not`.
"lear" -> "learn".