### PR TITLE
Use strict equals to compare animation values

### DIFF
--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -22,7 +22,7 @@ export default class AnimatedValue extends AnimatedNode {
 
   __detachAnimation(animation) {
     animation && animation.__detach();
-    if (this._animation == animation) {
+    if (this._animation === animation) {
       this._animation = null;
     }
   }


### PR DESCRIPTION
I believe this was a simple oversight.

If it's not, then a comment would seem warranted as to why.