### PR TITLE
Update diffClamp.js

### DIFF
--- a/src/derived/diffClamp.js
+++ b/src/derived/diffClamp.js
@@ -1,8 +1,8 @@
 import { cond, defined, set, add } from '../base';
 import AnimatedValue from '../core/AnimatedValue';
-import { min } from './min';
-import { max } from './max';
-import { diff } from './diff';
+import min from './min';
+import max from './max';
+import diff from './diff';
 
 export default function diffClamp(a, minVal, maxVal) {
   const value = new AnimatedValue();


### PR DESCRIPTION
When using `diffClamp` function, an error is thrown.

The reason is that `min`, `max` and `diff` nodes are exported using default exports. This PR fixes the issue.