### PR TITLE
Color alpha should work with AnimatedNode

### DIFF
--- a/src/derived/color.js
+++ b/src/derived/color.js
@@ -1,9 +1,9 @@
 import { cond, lessThan, multiply, round, add, sub } from '../base';
 import { Platform } from 'react-native';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedNode from '../core/AnimatedNode';
 
 export default function color(r, g, b, a = 1) {
-  if (a instanceof AnimatedValue) {
+  if (a instanceof AnimatedNode) {
     a = round(multiply(a, 255));
   } else {
     a = Math.round(a * 255);


### PR DESCRIPTION
This enables `color` to work in the event that the `alpha` value for a color is a derived node rather than explicitly an `AnimatedValue`