### PR TITLE
Remove reference to _offet

### DIFF
--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -36,7 +36,7 @@ export default class AnimatedValue extends AnimatedNode {
     if (this.__inputNodes && this.__inputNodes.length) {
       this.__inputNodes.forEach(val);
     }
-    return this._value + this._offset;
+    return this._value;
   }
 
   _updateValue(value) {


### PR DESCRIPTION
Remove an addition to an uninitialized field which would have led `__onEvaluate()` to return `NaN`.

Note that it is not wise to request the current value of an AnimatedValue, as that should almost always be done within the native ObjC or Java code.