### PR TITLE
Props and style sensitive for props changes

### DIFF
--- a/src/core/AnimatedProps.js
+++ b/src/core/AnimatedProps.js
@@ -30,7 +30,7 @@ export function createOrReusePropsNode(props, callback, oldNode) {
   }
   const config = sanitizeProps(props);
   if (oldNode && deepEqual(config, oldNode._config)) {
-    oldNode.__setNewProps(props);
+    oldNode._props = props;
     return oldNode;
   }
   return new AnimatedProps(props, config, callback);
@@ -46,10 +46,6 @@ class AnimatedProps extends AnimatedNode {
     this._props = props;
     this._callback = callback;
     this.__attach();
-  }
-
-  __setNewProps(newProps) {
-    this._props = newProps;
   }
 
   __getProps() {

--- a/src/core/AnimatedProps.js
+++ b/src/core/AnimatedProps.js
@@ -30,7 +30,6 @@ export function createOrReusePropsNode(props, callback, oldNode) {
   }
   const config = sanitizeProps(props);
   if (oldNode && deepEqual(config, oldNode._config)) {
-    oldNode._props = props;
     return oldNode;
   }
   return new AnimatedProps(props, config, callback);

--- a/src/core/AnimatedProps.js
+++ b/src/core/AnimatedProps.js
@@ -48,21 +48,6 @@ class AnimatedProps extends AnimatedNode {
     this.__attach();
   }
 
-  __getProps() {
-    const props = {};
-    for (const key in this._props) {
-      const value = this._props[key];
-      if (value instanceof AnimatedNode) {
-        if (value instanceof AnimatedStyle) {
-          props[key] = value.__getProps();
-        }
-      } else {
-        props[key] = value;
-      }
-    }
-    return props;
-  }
-
   __onEvaluate() {
     const props = {};
     for (const key in this._props) {

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -56,7 +56,7 @@ export default class AnimatedStyle extends AnimatedNode {
     for (const key in style) {
       const value = style[key];
       if (value instanceof AnimatedNode) {
-        // no-op
+        // do nothing
       } else if (value && !Array.isArray(value) && typeof value === 'object') {
         // Support animating nested values (for example: shadowOffset.height)
         updatedStyle[key] = this._walkStyleAndGetValues(value);

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -1,9 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 import AnimatedNode from './AnimatedNode';
-import AnimatedTransform, {
-  createOrReuseTransformNode,
-} from './AnimatedTransform';
+import { createOrReuseTransformNode } from './AnimatedTransform';
 
 import deepEqual from 'fbjs/lib/areEqual';
 

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -29,7 +29,6 @@ export function createOrReuseStyleNode(style, oldNode) {
   }
   const config = sanitizeStyle(style);
   if (oldNode && deepEqual(config, oldNode._config)) {
-    oldNode._style = style;
     return oldNode;
   }
   return new AnimatedStyle(style, config);

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -58,9 +58,7 @@ export default class AnimatedStyle extends AnimatedNode {
     for (const key in style) {
       const value = style[key];
       if (value instanceof AnimatedNode) {
-        if (value instanceof AnimatedTransform) {
-          updatedStyle[key] = value.__getProps();
-        }
+        // no-op
       } else if (value && !Array.isArray(value) && typeof value === 'object') {
         // Support animating nested values (for example: shadowOffset.height)
         updatedStyle[key] = this._walkStyleAndGetValues(value);

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -46,27 +46,6 @@ export default class AnimatedStyle extends AnimatedNode {
     this._style = style;
   }
 
-  // Recursively get values for nested styles (like iOS's shadowOffset)
-  _walkStyleAndGetValues(style) {
-    const updatedStyle = {};
-    for (const key in style) {
-      const value = style[key];
-      if (value instanceof AnimatedNode) {
-        // do nothing
-      } else if (value && !Array.isArray(value) && typeof value === 'object') {
-        // Support animating nested values (for example: shadowOffset.height)
-        updatedStyle[key] = this._walkStyleAndGetValues(value);
-      } else {
-        updatedStyle[key] = value;
-      }
-    }
-    return updatedStyle;
-  }
-
-  __getProps() {
-    return this._walkStyleAndGetValues(this._style);
-  }
-
   _walkStyleAndGetAnimatedValues(style) {
     const updatedStyle = {};
     for (const key in style) {

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -29,7 +29,7 @@ export function createOrReuseStyleNode(style, oldNode) {
   }
   const config = sanitizeStyle(style);
   if (oldNode && deepEqual(config, oldNode._config)) {
-    oldNode.__setNewStyle(style);
+    oldNode._style = style;
     return oldNode;
   }
   return new AnimatedStyle(style, config);
@@ -44,10 +44,6 @@ export default class AnimatedStyle extends AnimatedNode {
     super({ type: 'style', style: config }, Object.values(style));
     this._config = config;
     this._style = style;
-  }
-
-  __setNewStyle(newStyle) {
-    this._style = newStyle;
   }
 
   // Recursively get values for nested styles (like iOS's shadowOffset)

--- a/src/core/AnimatedStyle.js
+++ b/src/core/AnimatedStyle.js
@@ -1,7 +1,9 @@
 import { StyleSheet } from 'react-native';
 
 import AnimatedNode from './AnimatedNode';
-import { createOrReuseTransformNode } from './AnimatedTransform';
+import AnimatedTransform, {
+  createOrReuseTransformNode,
+} from './AnimatedTransform';
 
 import deepEqual from 'fbjs/lib/areEqual';
 
@@ -56,7 +58,9 @@ export default class AnimatedStyle extends AnimatedNode {
     for (const key in style) {
       const value = style[key];
       if (value instanceof AnimatedNode) {
-        // do nothing
+        if (value instanceof AnimatedTransform) {
+          updatedStyle[key] = value.__getProps();
+        }
       } else if (value && !Array.isArray(value) && typeof value === 'object') {
         // Support animating nested values (for example: shadowOffset.height)
         updatedStyle[key] = this._walkStyleAndGetValues(value);

--- a/src/core/AnimatedTransform.js
+++ b/src/core/AnimatedTransform.js
@@ -12,6 +12,11 @@ function sanitizeTransform(inputTransform) {
           property: key,
           nodeID: value.__nodeID,
         });
+      } else {
+        outputTransform.push({
+          property: key,
+          value,
+        });
       }
     }
   });
@@ -34,7 +39,6 @@ function extractAnimatedParentNodes(transform) {
 export function createOrReuseTransformNode(transform, oldNode) {
   const config = sanitizeTransform(transform);
   if (oldNode && deepEqual(config, oldNode._config)) {
-    oldNode.__setNewTransform(transform);
     return oldNode;
   }
   return new AnimatedTransform(transform, config);
@@ -48,25 +52,6 @@ export default class AnimatedTransform extends AnimatedNode {
     );
     this._config = config;
     this._transform = transform;
-  }
-
-  __setNewTransform(newTransform) {
-    this._transform = newTransform;
-  }
-  __getProps() {
-    const result = [];
-    for (let i = 0; i < this._transform.length; i++) {
-      const transform = this._transform[i];
-      for (const key in transform) {
-        const value = transform[key];
-        if (!(value instanceof AnimatedNode)) {
-          const singleTransform = {};
-          singleTransform[key] = value;
-          result.push(singleTransform);
-        }
-      }
-    }
-    return result;
   }
 
   __onEvaluate() {

--- a/src/core/AnimatedTransform.js
+++ b/src/core/AnimatedTransform.js
@@ -44,7 +44,7 @@ export function createOrReuseTransformNode(transform, oldNode) {
   return new AnimatedTransform(transform, config);
 }
 
-export default class AnimatedTransform extends AnimatedNode {
+class AnimatedTransform extends AnimatedNode {
   constructor(transform, config) {
     super(
       { type: 'transform', transform: config },

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -92,24 +92,26 @@ export default function createAnimatedComponent(Component) {
       for (const key in this.props) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
-          nextEvts.add(prop);
+          // need to use prop.__nodeID instead of simply node because of error in JSC
+          // because freezen objects connot be used in Set fom some reason.
+          nextEvts.add(prop.__nodeID);
         }
       }
       for (const key in prevProps) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
-          if (!nextEvts.has(prop)) {
+          if (!nextEvts.has(prop.__nodeID)) {
             // event was in prev props but not in current props, we detach
             prop.detachEvent(node, key);
           } else {
             // event was in prev and is still in current props
-            attached.add(prop);
+            attached.add(prop.__nodeID);
           }
         }
       }
       for (const key in this.props) {
         const prop = this.props[key];
-        if (prop instanceof AnimatedEvent && !attached.has(prop)) {
+        if (prop instanceof AnimatedEvent && !attached.has(prop.__nodeID)) {
           // not yet attached
           prop.attachEvent(node, key);
         }
@@ -183,10 +185,7 @@ export default function createAnimatedComponent(Component) {
       if (this._component !== this._prevComponent) {
         this._propsAnimated.setNativeView(this._component);
       }
-    }
-
-    componentDidUpdate(prevProps) {
-      this._reattachNativeEvents(prevProps);
+      this._reattachNativeEvents(this.props);
     }
 
     _setComponentRef(c) {

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { findNodeHandle } from 'react-native';
+import { findNodeHandle, StyleSheet } from 'react-native';
 import ReanimatedEventEmitter from './ReanimatedEventEmitter';
 import ViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes';
 
 import AnimatedEvent from './core/AnimatedEvent';
+import AnimatedNode from './core/AnimatedNode';
 import { createOrReusePropsNode } from './core/AnimatedProps';
 
 import invariant from 'fbjs/lib/invariant';
@@ -175,12 +176,8 @@ export default function createAnimatedComponent(Component) {
       }
     }
 
-    shouldComponentUpdate(nextProps) {
-      this._attachProps(nextProps);
-      return true;
-    }
-
     componentDidUpdate(prevProps) {
+      this._attachProps(this.props);
       this._reattachNativeEvents(prevProps);
       if (this._refHasChanged) {
         this._refHasChanges = false;
@@ -195,8 +192,32 @@ export default function createAnimatedComponent(Component) {
       }
     };
 
+    _filterNonAnimatedStyle(inputStyle) {
+      const style = {};
+      for (const key in inputStyle) {
+        const value = inputStyle[key];
+        if (!(value instanceof AnimatedNode) && key !== 'transform') {
+          style[key] = value;
+        }
+      }
+      return style;
+    }
+
+    _filterNonAnimatedProps(inputProps) {
+      const props = {};
+      for (const key in inputProps) {
+        const value = inputProps[key];
+        if (key === 'style') {
+          props[key] = this._filterNonAnimatedStyle(StyleSheet.flatten(value));
+        } else if (!(value instanceof AnimatedNode)) {
+          props[key] = value;
+        }
+      }
+      return props;
+    }
+
     render() {
-      const props = this._propsAnimated.__getProps();
+      const props = this._filterNonAnimatedProps(this.props);
       return (
         <Component {...props} ref={this._setComponentRef} collapsable={false} />
       );

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -93,7 +93,7 @@ export default function createAnimatedComponent(Component) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
           // need to use prop.__nodeID instead of simply node because of error in JSC
-          // because freezen objects connot be used in Set fom some reason.
+          // because frozen objects cannot be used in Set fom some reason.
           nextEvts.add(prop.__nodeID);
         }
       }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -92,8 +92,8 @@ export default function createAnimatedComponent(Component) {
       for (const key in this.props) {
         const prop = this.props[key];
         if (prop instanceof AnimatedEvent) {
-          // need to use prop.__nodeID instead of simply node because of error in JSC
-          // because frozen objects cannot be used in Set fom some reason.
+          // need to use `prop.__nodeID` instead of simply `prop` because of a limitation in JSC.
+          // frozen objects cannot be used in Set fom some reason.
           nextEvts.add(prop.__nodeID);
         }
       }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -24,6 +24,10 @@ export default function createAnimatedComponent(Component) {
   );
 
   class AnimatedComponent extends React.Component {
+    constructor(props) {
+      super(props);
+      this._setComponentRef = this._setComponentRef.bind(this);
+    }
     _invokeAnimatedPropsCallbackOnMount = false;
 
     componentWillUnmount() {
@@ -174,19 +178,26 @@ export default function createAnimatedComponent(Component) {
       }
     }
 
+    componentWillReceiveProps(newProps) {
+      this._attachProps(newProps);
+      if (this._component !== this._prevComponent) {
+        this._propsAnimated.setNativeView(this._component);
+      }
+    }
+
     componentDidUpdate(prevProps) {
-      this._attachProps(this.props);
       this._reattachNativeEvents(prevProps);
+    }
+
+    _setComponentRef(c) {
+      this._prevComponent = this._component;
+      this._component = c;
     }
 
     render() {
       const props = this._propsAnimated.__getProps();
       return (
-        <Component
-          {...props}
-          ref={ref => (this._component = ref)}
-          collapsable={false}
-        />
+        <Component {...props} ref={this._setComponentRef} collapsable={false} />
       );
     }
 


### PR DESCRIPTION
## Motivation 
It was impossible to manipulate component via props which seems to be the most obvious way of applying changes into existing components

## Changes
1. Attaching props has been moved to `shouldComponentUpdate` method in order to handle case when props are being change. 

2. Adding possibility to applying primitive types to transform map

3. Remove checking if primitive types are changed in `TransformNode` which is no longes necessary if we handle this changes in reactive way 

4. Add possibility to change reference to View in Animated View which is common situation if we use props to manage some properties


Changes has been explained also in inline comments

It fixes https://github.com/kmagiera/react-native-reanimated/issues/28, https://github.com/kmagiera/react-native-reanimated/issues/62 and maybe https://github.com/kmagiera/react-native-reanimated/issues/27 (no repro context added)


Example below

https://gist.github.com/osdnk/2e98d8c78ab60b580fb09de17f5c1cb0