### PR TITLE
Always call `setNativeView` in `componentDidUpdate`

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -26,7 +26,7 @@ export default function createAnimatedComponent(Component) {
 
   class AnimatedComponent extends React.Component {
     _invokeAnimatedPropsCallbackOnMount = false;
-    _refHasChanges = false;
+    _refHasChanged = false;
 
     componentWillUnmount() {
       this._detachPropUpdater();
@@ -180,7 +180,7 @@ export default function createAnimatedComponent(Component) {
       this._attachProps(this.props);
       this._reattachNativeEvents(prevProps);
       if (this._refHasChanged) {
-        this._refHasChanges = false;
+        this._refHasChanged = false;
         this._propsAnimated.setNativeView(this._component);
       }
     }

--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -26,7 +26,6 @@ export default function createAnimatedComponent(Component) {
 
   class AnimatedComponent extends React.Component {
     _invokeAnimatedPropsCallbackOnMount = false;
-    _refHasChanged = false;
 
     componentWillUnmount() {
       this._detachPropUpdater();
@@ -179,16 +178,13 @@ export default function createAnimatedComponent(Component) {
     componentDidUpdate(prevProps) {
       this._attachProps(this.props);
       this._reattachNativeEvents(prevProps);
-      if (this._refHasChanged) {
-        this._refHasChanged = false;
-        this._propsAnimated.setNativeView(this._component);
-      }
+
+      this._propsAnimated.setNativeView(this._component);
     }
 
     _setComponentRef = c => {
       if (c !== this._component) {
         this._component = c;
-        this._refHasChanged = true;
       }
     };
 


### PR DESCRIPTION
I noticed this error when porting this code to RN implementation. Sometimes the flag is called `_refHasChanged` and sometimes `_refHasChanges` which causes it to stay true forever if set.

Edit: Actually the fact that it stays true forever hid a bug, `setNativeView` needs to always be called in `componentDidUpdate` because it is possible that `_propsAnimated` changed and the new instance does not have the view set. In this case we need to call it even if the ref did not change. `setNativeView` already no-ops if the ref is the same so no need to do any checks.