### PR TITLE
Add __isNative AnimatedEvent

### DIFF
--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -36,6 +36,7 @@ export default class AnimatedEvent extends AnimatedNode {
   constructor(argMapping, config = {}) {
     super({ type: 'event', argMapping: sanitizeArgMapping(argMapping) });
   }
+  // this field has been made to be compatible with RN and is used by RNGH
   __isNative = true;
 
   attachEvent(viewRef, eventName) {

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -36,6 +36,7 @@ export default class AnimatedEvent extends AnimatedNode {
   constructor(argMapping, config = {}) {
     super({ type: 'event', argMapping: sanitizeArgMapping(argMapping) });
   }
+  __isNative = true;
 
   attachEvent(viewRef, eventName) {
     this.__attach();

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -36,7 +36,8 @@ export default class AnimatedEvent extends AnimatedNode {
   constructor(argMapping, config = {}) {
     super({ type: 'event', argMapping: sanitizeArgMapping(argMapping) });
   }
-  // the below field is a temporary workaround to make AnimatedEvent object be recognized
+  
+  // The below field is a temporary workaround to make AnimatedEvent object be recognized
   // and filtered out by gesture handler library that relies on it being available when
   // Animated.event is used instead of a callback for processing events.
   __isNative = true;

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -36,7 +36,9 @@ export default class AnimatedEvent extends AnimatedNode {
   constructor(argMapping, config = {}) {
     super({ type: 'event', argMapping: sanitizeArgMapping(argMapping) });
   }
-  // this field has been made to be compatible with RN and is used by RNGH
+  // the below field is a temporary workaround to make AnimatedEvent object be recognized
+  // and filtered out by gesture handler library that relies on it being available when
+  // Animated.event is used instead of a callback for processing events.
   __isNative = true;
 
   attachEvent(viewRef, eventName) {

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -38,8 +38,8 @@ export default class AnimatedEvent extends AnimatedNode {
   }
   
   // The below field is a temporary workaround to make AnimatedEvent object be recognized
-  // and filtered out by gesture handler library that relies on it being available when
-  // Animated.event is used instead of a callback for processing events.
+  // as Animated.event event callback and therefore filtered out from being send over the
+  // bridge which was causing the object to be frozen in JS.
   __isNative = true;
 
   attachEvent(viewRef, eventName) {


### PR DESCRIPTION
Make to be compatible with RN https://github.com/facebook/react-native/blob/5c2720b089dd0fb277771b0ac8b0e7788c493e5d/Libraries/Animated/src/AnimatedEvent.js#L96

and handle not sending events to native via bridge via RNGH