### PR TITLE
Add jsDebug derived node

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ or
 ```js
 jsDebug(node, type = 'log')
 ```
-`message` cannot be `animatedNode` and could be omitted. If there's given message it will concatenated with `node`. `type` could be 'log', 'warn', 'error' of any other console log type supported by React Native.
+`message` cannot be `animatedNode` and could be omitted. If there's given message it will concatenated with `node`. `type` could be 'log', 'warn', 'error' or any other console log type supported by React Native.
 
 ---
 ### `interpolate`

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ or
 ```js
 jsDebug(node, type = 'log')
 ```
-`message` cannot be `animatedNode` ans could be omitted. If there's given message it will concatenated with `node`. `type` could be 'log', 'warn', 'error' of any other console log type supported by React Native.
+`message` cannot be `animatedNode` and could be omitted. If there's given message it will concatenated with `node`. `type` could be 'log', 'warn', 'error' of any other console log type supported by React Native.
 
 ---
 ### `interpolate`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Takes an array of nodes and evaluates all the nodes in the order they are put in
 debug(messageString, valueNode)
 ```
 
-When the node is evaluated it prints to the console (using `console.log` or other means on native) a string that contains the `messageString` concatenated with the value of `valueNode`. Then returns the value of `valueNode`. Note that `messageString` should be a normal string not an animated node.
+When the node is evaluated it prints to the console (via native logs) a string that contains the `messageString` concatenated with the value of `valueNode`. Then returns the value of `valueNode`. Note that `messageString` should be a normal string not an animated node.
 
 ---
 ### `startClock`
@@ -492,6 +492,21 @@ Returns an accumulated value of the given node. This node stores a sum of all ev
 ### `diffClamp`
 
 Works the same way as with the original Animated library.
+
+---
+### `jsDebug`
+
+When the node is evaluated it prints to the console in JavaScript debugger.
+It's helpful while debugging with Expo.
+It might be used with optional message text:
+```js
+jsDebug(message, node, type = 'log')
+```
+or
+```js
+jsDebug(node, type = 'log')
+```
+`message` cannot be `animatedNode` ans could be omitted. If there's given message it will concatenated with `node`. `type` could be 'log', 'warn', 'error' of any other console log type supported by React Native.
 
 ---
 ### `interpolate`

--- a/src/derived/index.js
+++ b/src/derived/index.js
@@ -9,3 +9,4 @@ export { default as min } from './min';
 export { default as onChange } from './onChange';
 export { default as floor } from './floor';
 export { default as ceil } from './ceil';
+export { default as jsDebug } from './jsDebug';

--- a/src/derived/jsDebug.js
+++ b/src/derived/jsDebug.js
@@ -1,4 +1,4 @@
-import { cond, block, defined, sub, set, call } from '../base';
+import { block, call } from '../base';
 import AnimatedNode from '../core/AnimatedNode';
 
 export default function jsDebug(message, node, type = 'log') {

--- a/src/derived/jsDebug.js
+++ b/src/derived/jsDebug.js
@@ -1,0 +1,14 @@
+import { cond, block, defined, sub, set, call } from '../base';
+import AnimatedNode from '../core/AnimatedNode';
+
+export default function jsDebug(message, node, type = 'log') {
+  // missing message, node might mean type
+  if (message instanceof AnimatedNode) {
+    return block([
+      call([message], ([a]) => console[node === null ? 'log' : node](a)),
+      message,
+    ]);
+  }
+  // message is present
+  return block([call([node], ([a]) => console[type](`${message} ${a}`)), node]);
+}


### PR DESCRIPTION
## Motivation
It might be difficult ot use native loggers on each debugging.

`jsDebug` is using `console.log`s and could be a handy replacement for `debug` if needed