### PR TITLE
Add color as a whitelisted native prop

### DIFF
--- a/src/ConfigHelper.js
+++ b/src/ConfigHelper.js
@@ -104,6 +104,8 @@ let NATIVE_THREAD_PROPS_WHITELIST = {
   textDecorationStyle: true,
   textTransform: true,
   writingDirection: true,
+  /* text color */
+  color: true,
 };
 
 function configureProps() {


### PR DESCRIPTION
Hopefully this should be a native prop and not a UI prop — text color animates after I call `addWhitelistedNativeProps({ color: true })`

Closes #99