### PR TITLE
Fix interpolate example on Android

### DIFF
--- a/Example/src/interpolate/AnimatedBounds.js
+++ b/Example/src/interpolate/AnimatedBounds.js
@@ -70,7 +70,7 @@ export default class AnimatedBounds extends Component {
 
     const dragX = new Value(0);
     const state = new Value(-1);
-    const transX = new Value();
+    const transX = new Value(0);
     const prevDragX = new Value(0);
 
     this._onGestureEvent = event([


### PR DESCRIPTION
Since we allow more types to be handled, null is no loner casting to 0 on android