### PR TITLE
Add default value to AnimatedValue

### DIFF
--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -12,7 +12,7 @@ function sanitizeValue(value) {
 }
 
 export default class AnimatedValue extends AnimatedNode {
-  constructor(value) {
+  constructor(value = 0) {
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;
     this._animation = null;


### PR DESCRIPTION
According to https://github.com/kmagiera/react-native-reanimated/pull/113

Since we allow more types to be handled, null is no loner casting to 0 on android. It also implies some bugs on detaching on iOS related to calling callback with Null value which is not supported on objC