### PR TITLE
EasingStatic references Animated.EasingFunction but it's not being exported

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -86,7 +86,7 @@ declare module 'react-native-reanimated' {
       time: AnimatedValue<number>;
       frameTime: AnimatedValue<number>;
     }
-    type EasingFunction = (value: Adaptable<number>) => AnimatedNode<number>;
+    export type EasingFunction = (value: Adaptable<number>) => AnimatedNode<number>;
     export interface TimingConfig {
       toValue: Adaptable<number>;
       duration: Adaptable<number>;


### PR DESCRIPTION
Trying to use reanimated with typescript results in bunch of `Namespace 'Animated' has no exported member 'EasingFunction'` errors because `Animated.EasingFunction` is not being exported.