### PR TITLE
Add Animated.Code component to TS types

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -133,6 +133,11 @@ declare module 'react-native-reanimated' {
         : P[K] | AnimatedNode<P[K]>
     };
 
+    type CodeProps = {
+      exec?: AnimatedNode<number>
+      children?: () => AnimatedNode<number>
+    };
+    
     // components
     export const View: ComponentClass<AnimateProps<ViewStyle, ViewProps>>;
     export const Text: ComponentClass<AnimateProps<TextStyle, TextProps>>;
@@ -140,6 +145,7 @@ declare module 'react-native-reanimated' {
     export const ScrollView: ComponentClass<
       AnimateProps<ViewStyle, ScrollViewProps>
     >;
+    export const Code: ComponentClass<CodeProps>;
 
     // classes
     export {


### PR DESCRIPTION
Adds the `<Animated.Code>` component and a props type for a render or `exec` prop. Is it right that this should always return an `AnimatedNode<number>`?

Render prop or `exec` should be exclusive, based on how its implemented (`exec` takes precedence), but my TypeScript experience is too limited to figure that out.