### PR TITLE
Update react-native-reanimated.d.ts

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -54,7 +54,7 @@ declare module 'react-native-reanimated' {
       interpolate(config: InterpolationConfig): AnimatedNode<number>;
     }
 
-    export type Mapping = { [key: string]: Mapping } | AnimatedValue<any>;
+    export type Mapping = { [key: string]: Mapping } | Adaptable<any>;
     export type Adaptable<T> =
       | T
       | AnimatedNode<T>


### PR DESCRIPTION
Fix Mapping declaration since [native event can be a function](https://github.com/kmagiera/react-native-reanimated/pull/83)

Otherwise, you will get an error like this:

"Type '{ nativeEvent: ({ translationY: y, state }: { translationY: number; state: State; }) => AnimatedNode<number>; }' is not assignable to type 'Mapping'.