### PR TITLE
Revert back to typeof to avoid ReferenceError: Can't find variable Proxy

### DIFF
--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -57,9 +57,10 @@ function sanitizeArgMapping(argMapping) {
       },
     };
 
-    const proxy = Proxy
-      ? new Proxy({}, proxyHandler)
-      : createEventObjectProxyPolyfill();
+    const proxy =
+      typeof Proxy === 'function'
+        ? new Proxy({}, proxyHandler)
+        : createEventObjectProxyPolyfill();
     alwaysNodes.push(new AnimatedAlways(ev(proxy)));
     traverse(proxy, []);
   }


### PR DESCRIPTION
@osdnk I'm sorry about this but accessing Proxy will result in a ReferenceError on Android and iOS 8 & 9