### PR TITLE
Improve progress example

### DIFF
--- a/Example/progressBar/index.js
+++ b/Example/progressBar/index.js
@@ -20,8 +20,11 @@ export default class Progressable extends Component {
       this.setState({
         progress,
       });
-      progress += 0.01;
-    }, 100);
+      progress += 0.1;
+      if (progress > 1) {
+        clearInterval(this.timeout);
+      }
+    }, 1000);
   };
 
   componentDidMount() {


### PR DESCRIPTION
I think it's more natural if animation do not perform so often. Once per second looks better imho and it's a better example of this library usage. 

Also, removed animations if "fetch" is finished