### PR TITLE
Use versions from project configuration if available.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,17 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion safeExtGet('compileSdkVersion', 25)
+    buildToolsVersion safeExtGet('buildToolsVersion', '25.0.2')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
If a project uses a different sdk for compiling they will run into issues with this project since the versions are hard coded. This applies a change similar to some other libraries to take the versions specified for the project or fallback to the currently hardcoded versions.