### PR TITLE
Support animating Svg Path d attribute on android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/PropsNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/PropsNode.java
@@ -87,6 +87,11 @@ public class PropsNode extends Node implements FinalNode {
               throw new IllegalArgumentException("Unexpected type " + type);
           }
         }
+      } else if (node instanceof ConcatNode) {
+        String key = entry.getKey();
+        String value = (String) node.value();
+        mPropMap.putString(key, value);
+        hasUIProps = true;
       } else {
         String key = entry.getKey();
         if (mNodesManager.uiProps.contains(key)) {


### PR DESCRIPTION
https://github.com/react-native-community/react-native-svg/issues/908

```jsx
import * as React from 'react';
import { View, StyleSheet } from 'react-native';
import { Svg, Path } from 'react-native-svg';
import Animated from 'react-native-reanimated';

const { concat, multiply } = Animated;
const x = multiply(1, 2);
const y = multiply(2, 3);
const path = concat('M 0 0 L ', x, ' ', y);

const AnimatedPath = Animated.createAnimatedComponent(Path);

export default class App extends React.Component {
  render() {
    return (
      <View style={styles.container}>
        <Svg viewBox="0 0 10 10" width="100" height="100">
          <AnimatedPath d={path} stroke="black" />
        </Svg>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    backgroundColor: '#ecf0f1',
  },
});
```