### PR TITLE
Remove prop-types from AnimatedComponent

### DIFF
--- a/src/createAnimatedComponent.js
+++ b/src/createAnimatedComponent.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { findNodeHandle, StyleSheet } from 'react-native';
 import ReanimatedEventEmitter from './ReanimatedEventEmitter';
-import ViewStylePropTypes from 'react-native/Libraries/DeprecatedPropTypes/DeprecatedViewStylePropTypes';
 
 import AnimatedEvent from './core/AnimatedEvent';
 import AnimatedNode from './core/AnimatedNode';
@@ -225,30 +224,6 @@ export default function createAnimatedComponent(Component) {
       return this._component;
     }
   }
-
-  const propTypes = Component.propTypes;
-
-  AnimatedComponent.propTypes = {
-    style: function(props, propName, componentName) {
-      if (!propTypes) {
-        return;
-      }
-
-      for (const key in ViewStylePropTypes) {
-        if (!propTypes[key] && props[key] !== undefined) {
-          console.warn(
-            'You are setting the style `{ ' +
-              key +
-              ': ... }` as a prop. You ' +
-              'should nest it in a style object. ' +
-              'E.g. `{ style: { ' +
-              key +
-              ': ... } }`'
-          );
-        }
-      }
-    },
-  };
 
   return AnimatedComponent;
 }


### PR DESCRIPTION
Proptypes are no longer supported by RN and has been removed from core of RN in favor of Flow.

It fixes this commit and merging it was a mistake.
https://github.com/kmagiera/react-native-reanimated/commit/e75377aa98a2baaf9e9c23e73663d340934b4b0e
