### PR TITLE
Remove dependencies' cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "1.0.0-alpha.11",
+  "version": "1.0.0-alpha.12",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -18,7 +18,6 @@ import {
   addWhitelistedUIProps,
 } from './ConfigHelper';
 import backwardCompatibleAnimWrapper from './animations/backwardCompatibleAnimWrapper';
-
 const Animated = {
   // components
   View: createAnimatedComponent(View),

--- a/src/animations/DecayAnimation.js
+++ b/src/animations/DecayAnimation.js
@@ -3,7 +3,7 @@ import Animation from './Animation';
 import decay from './decay';
 import { block, clockRunning, startClock, stopClock, cond } from '../base';
 import Clock from '../core/AnimatedClock';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 
 class DecayAnimation extends Animation {
   constructor(config) {

--- a/src/animations/SpringAnimation.js
+++ b/src/animations/SpringAnimation.js
@@ -1,4 +1,4 @@
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 import Animation from './Animation';
 import SpringConfig from '../SpringConfig';
 import spring from './spring';

--- a/src/animations/TimingAnimation.js
+++ b/src/animations/TimingAnimation.js
@@ -1,4 +1,4 @@
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 import timing from './timing';
 import { block, clockRunning, startClock, stopClock, cond } from '../base';
 import Clock from '../core/AnimatedClock';

--- a/src/animations/spring.js
+++ b/src/animations/spring.js
@@ -18,7 +18,7 @@ import {
   greaterThan,
 } from '../base';
 import { min, abs } from '../derived';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 
 const MAX_STEPS_MS = 64;
 

--- a/src/base.js
+++ b/src/base.js
@@ -1,107 +1,16 @@
-import AnimatedCond from './core/AnimatedCond';
-import AnimatedSet from './core/AnimatedSet';
-import AnimatedOperator from './core/AnimatedOperator';
-import AnimatedStartClock from './core/AnimatedStartClock';
-import AnimatedStopClock from './core/AnimatedStopClock';
-import AnimatedClockTest from './core/AnimatedClockTest';
-import AnimatedDebug from './core/AnimatedDebug';
-import AnimatedCall from './core/AnimatedCall';
-import AnimatedEvent from './core/AnimatedEvent';
-import AnimatedAlways from './core/AnimatedAlways';
-import AnimatedConcat from './core/AnimatedConcat';
-
-import { adapt } from './utils';
-
-function operator(name) {
-  return (...args) => new AnimatedOperator(name, args.map(adapt));
-}
-
-export const add = operator('add');
-export const sub = operator('sub');
-export const multiply = operator('multiply');
-export const divide = operator('divide');
-export const pow = operator('pow');
-export const modulo = operator('modulo');
-export const sqrt = operator('sqrt');
-export const sin = operator('sin');
-export const cos = operator('cos');
-export const exp = operator('exp');
-export const round = operator('round');
-export const lessThan = operator('lessThan');
-export const eq = operator('eq');
-export const greaterThan = operator('greaterThan');
-export const lessOrEq = operator('lessOrEq');
-export const greaterOrEq = operator('greaterOrEq');
-export const neq = operator('neq');
-export const and = operator('and');
-export const or = operator('or');
-export const defined = operator('defined');
-export const not = operator('not');
-
-export const set = function(what, value) {
-  return new AnimatedSet(what, adapt(value));
-};
-
-export const cond = function(cond, ifBlock, elseBlock) {
-  return new AnimatedCond(
-    adapt(cond),
-    adapt(ifBlock),
-    elseBlock === undefined ? undefined : adapt(elseBlock)
-  );
-};
-
-export const block = function(items) {
-  return adapt(items);
-};
-
-export const call = function(args, func) {
-  return new AnimatedCall(args, func);
-};
-
-export const debug = function(message, value) {
-  if (__DEV__) {
-    const runningInRemoteDebugger = typeof atob !== 'undefined';
-    // hack to detect if app is running in remote debugger
-    // https://stackoverflow.com/questions/39022216
-
-    const runningInExpoShell =
-      global.Expo && global.Expo.Constants.appOwnership !== 'standalone';
-
-    if (runningInRemoteDebugger || runningInExpoShell) {
-      // When running in expo or remote debugger we use JS console.log to output variables
-      // otherwise we output to the native console using native debug node
-      return block([
-        call([value], ([a]) => console.log(`${message} ${a}`)),
-        value,
-      ]);
-    } else {
-      return new AnimatedDebug(message, adapt(value));
-    }
-  }
-  // Debugging is disabled in PROD
-  return value;
-};
-
-export const startClock = function(clock) {
-  return new AnimatedStartClock(clock);
-};
-
-export const always = function(item) {
-  return new AnimatedAlways(item);
-};
-
-export const concat = function(...args) {
-  return new AnimatedConcat(args.map(adapt));
-};
-
-export const stopClock = function(clock) {
-  return new AnimatedStopClock(clock);
-};
-
-export const clockRunning = function(clock) {
-  return new AnimatedClockTest(clock);
-};
-
-export const event = function(argMapping, config) {
-  return new AnimatedEvent(argMapping, config);
-};
+export { createAnimatedCond as cond } from './core/AnimatedCond';
+export { createAnimatedSet as set } from './core/AnimatedSet';
+export {
+  createAnimatedStartClock as startClock,
+} from './core/AnimatedStartClock';
+export { createAnimatedStopClock as stopClock } from './core/AnimatedStopClock';
+export {
+  createAnimatedClockTest as clockRunning,
+} from './core/AnimatedClockTest';
+export { createAnimatedDebug as debug } from './core/AnimatedDebug';
+export { createAnimatedCall as call } from './core/AnimatedCall';
+export { createAnimatedEvent as event } from './core/AnimatedEvent';
+export { createAnimatedAlways as always } from './core/AnimatedAlways';
+export { createAnimatedConcat as concat } from './core/AnimatedConcat';
+export { createAnimatedBlock as block, adapt } from './core/AnimatedBlock';
+export * from './operators';

--- a/src/core/AnimatedAlways.js
+++ b/src/core/AnimatedAlways.js
@@ -1,6 +1,6 @@
 import AnimatedNode from './AnimatedNode';
 
-export default class AnimatedAlways extends AnimatedNode {
+class AnimatedAlways extends AnimatedNode {
   _what;
 
   constructor(what) {

--- a/src/core/AnimatedAlways.js
+++ b/src/core/AnimatedAlways.js
@@ -12,3 +12,7 @@ export default class AnimatedAlways extends AnimatedNode {
     return 0;
   }
 }
+
+export function createAnimatedAlways(item) {
+  return new AnimatedAlways(item);
+}

--- a/src/core/AnimatedBezier.js
+++ b/src/core/AnimatedBezier.js
@@ -1,4 +1,4 @@
-import { val } from '../utils';
+import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
 
 // These values are established by empiricism with tests (tradeoff: performance VS precision)

--- a/src/core/AnimatedBlock.js
+++ b/src/core/AnimatedBlock.js
@@ -2,7 +2,7 @@ import AnimatedNode from './AnimatedNode';
 import { val } from '../val';
 import InternalAnimatedValue from './InternalAnimatedValue';
 
-export default class AnimatedBlock extends AnimatedNode {
+class AnimatedBlock extends AnimatedNode {
   _array;
 
   constructor(array) {

--- a/src/core/AnimatedBlock.js
+++ b/src/core/AnimatedBlock.js
@@ -1,5 +1,6 @@
 import AnimatedNode from './AnimatedNode';
-import { val } from '../utils';
+import { val } from '../val';
+import InternalAnimatedValue from './InternalAnimatedValue';
 
 export default class AnimatedBlock extends AnimatedNode {
   _array;
@@ -16,4 +17,25 @@ export default class AnimatedBlock extends AnimatedNode {
     });
     return result;
   }
+}
+
+export function createAnimatedBlock(items) {
+  return adapt(items);
+}
+
+function nodify(v) {
+  if (typeof v === 'object' && v.__isProxy) {
+    if (!v.__val) {
+      v.__val = new InternalAnimatedValue(0);
+    }
+    return v.__val;
+  }
+  // TODO: cache some typical static values (e.g. 0, 1, -1)
+  return v instanceof AnimatedNode ? v : new InternalAnimatedValue(v);
+}
+
+export function adapt(v) {
+  return Array.isArray(v)
+    ? new AnimatedBlock(v.map(node => adapt(node)))
+    : nodify(v);
 }

--- a/src/core/AnimatedCall.js
+++ b/src/core/AnimatedCall.js
@@ -9,7 +9,7 @@ function listener(data) {
   node && node._callback(data.args);
 }
 
-export default class AnimatedCall extends AnimatedNode {
+class AnimatedCall extends AnimatedNode {
   _callback;
   _args;
 

--- a/src/core/AnimatedCall.js
+++ b/src/core/AnimatedCall.js
@@ -1,5 +1,5 @@
 import ReanimatedEventEmitter from '../ReanimatedEventEmitter';
-import { val } from '../utils';
+import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
 
 const NODE_MAPPING = new Map();
@@ -39,4 +39,8 @@ export default class AnimatedCall extends AnimatedNode {
     this._callback(this._args.map(val));
     return 0;
   }
+}
+
+export function createAnimatedCall(args, func) {
+  return new AnimatedCall(args, func);
 }

--- a/src/core/AnimatedClock.js
+++ b/src/core/AnimatedClock.js
@@ -1,8 +1,8 @@
-import AnimatedValue from './AnimatedValue';
+import InternalAnimatedValue from './AnimatedValue';
 import AnimatedNode from './AnimatedNode';
-import { val } from '../utils';
+import { val } from '../val';
 
-class AnimatedMainClock extends AnimatedValue {
+class AnimatedMainClock extends InternalAnimatedValue {
   _frameCallback;
 
   constructor() {

--- a/src/core/AnimatedClockTest.js
+++ b/src/core/AnimatedClockTest.js
@@ -2,7 +2,7 @@ import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
 import invariant from 'fbjs/lib/invariant';
 
-export default class AnimatedClockTest extends AnimatedNode {
+class AnimatedClockTest extends AnimatedNode {
   _clockNode;
 
   constructor(clockNode) {

--- a/src/core/AnimatedClockTest.js
+++ b/src/core/AnimatedClockTest.js
@@ -18,3 +18,7 @@ export default class AnimatedClockTest extends AnimatedNode {
     return this._clockNode.isStarted() ? 1 : 0;
   }
 }
+
+export function createAnimatedClockTest(clock) {
+  return new AnimatedClockTest(clock);
+}

--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import AnimatedAlways from './AnimatedAlways';
+import { createAnimatedAlways } from './AnimatedAlways';
 
 class Code extends React.Component {
   componentDidMount() {
-    this.always = new AnimatedAlways(
+    this.always = createAnimatedAlways(
       this.props.exec ? this.props.exec : this.props.children()
     );
     this.always.__attach();

--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import AnimatedAlways from './AnimatedAlways';
+import { createAnimatedAlways } from './AnimatedAlways';
 import AnimatedNode from './AnimatedNode';
 
 class Code extends React.Component {
@@ -33,7 +33,7 @@ class Code extends React.Component {
       );
     }
 
-    this.always = new AnimatedAlways(nodeExec || nodeChildren);
+    this.always = createAnimatedAlways(nodeExec || nodeChildren);
     this.always.__attach();
   }
 

--- a/src/core/AnimatedConcat.js
+++ b/src/core/AnimatedConcat.js
@@ -1,7 +1,7 @@
 import AnimatedNode from './AnimatedNode';
 import { adapt } from '../core/AnimatedBlock';
 
-export default class AnimatedConcat extends AnimatedNode {
+class AnimatedConcat extends AnimatedNode {
   constructor(input) {
     super({ type: 'concat', input: input.map(n => n.__nodeID) }, input);
   }

--- a/src/core/AnimatedConcat.js
+++ b/src/core/AnimatedConcat.js
@@ -1,7 +1,12 @@
 import AnimatedNode from './AnimatedNode';
+import { adapt } from '../core/AnimatedBlock';
 
 export default class AnimatedConcat extends AnimatedNode {
   constructor(input) {
     super({ type: 'concat', input: input.map(n => n.__nodeID) }, input);
   }
+}
+
+export function createAnimatedConcat(...args) {
+  return new AnimatedConcat(args.map(adapt));
 }

--- a/src/core/AnimatedCond.js
+++ b/src/core/AnimatedCond.js
@@ -1,5 +1,6 @@
-import { val } from '../utils';
+import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
+import { adapt } from '../core/AnimatedBlock';
 
 export default class AnimatedCond extends AnimatedNode {
   _condition;
@@ -28,4 +29,12 @@ export default class AnimatedCond extends AnimatedNode {
       return this._elseBlock !== undefined ? val(this._elseBlock) : undefined;
     }
   }
+}
+
+export function createAnimatedCond(cond, ifBlock, elseBlock) {
+  return new AnimatedCond(
+    adapt(cond),
+    adapt(ifBlock),
+    elseBlock === undefined ? undefined : adapt(elseBlock)
+  );
 }

--- a/src/core/AnimatedCond.js
+++ b/src/core/AnimatedCond.js
@@ -2,7 +2,7 @@ import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
 import { adapt } from '../core/AnimatedBlock';
 
-export default class AnimatedCond extends AnimatedNode {
+class AnimatedCond extends AnimatedNode {
   _condition;
   _ifBlock;
   _elseBlock;

--- a/src/core/AnimatedDebug.js
+++ b/src/core/AnimatedDebug.js
@@ -1,7 +1,6 @@
 import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
-import { adapt } from '../core/AnimatedBlock';
-import { createAnimatedBlock as block } from './AnimatedBlock';
+import { createAnimatedBlock as block, adapt } from './AnimatedBlock';
 import { createAnimatedCall as call } from './AnimatedCall';
 
 export default class AnimatedDebug extends AnimatedNode {

--- a/src/core/AnimatedDebug.js
+++ b/src/core/AnimatedDebug.js
@@ -3,7 +3,7 @@ import AnimatedNode from './AnimatedNode';
 import { createAnimatedBlock as block, adapt } from './AnimatedBlock';
 import { createAnimatedCall as call } from './AnimatedCall';
 
-export default class AnimatedDebug extends AnimatedNode {
+class AnimatedDebug extends AnimatedNode {
   _message;
   _value;
 

--- a/src/core/AnimatedDebug.js
+++ b/src/core/AnimatedDebug.js
@@ -1,5 +1,8 @@
-import { val } from '../utils';
+import { val } from '../val';
 import AnimatedNode from './AnimatedNode';
+import { adapt } from '../core/AnimatedBlock';
+import { createAnimatedBlock as block } from './AnimatedBlock';
+import { createAnimatedCall as call } from './AnimatedCall';
 
 export default class AnimatedDebug extends AnimatedNode {
   _message;
@@ -16,4 +19,28 @@ export default class AnimatedDebug extends AnimatedNode {
     console.log(this._message, value);
     return value;
   }
+}
+
+export function createAnimatedDebug(message, value) {
+  if (__DEV__) {
+    const runningInRemoteDebugger = typeof atob !== 'undefined';
+    // hack to detect if app is running in remote debugger
+    // https://stackoverflow.com/questions/39022216
+
+    const runningInExpoShell =
+      global.Expo && global.Expo.Constants.appOwnership !== 'standalone';
+
+    if (runningInRemoteDebugger || runningInExpoShell) {
+      // When running in expo or remote debugger we use JS console.log to output variables
+      // otherwise we output to the native console using native debug node
+      return block([
+        call([value], ([a]) => console.log(`${message} ${a}`)),
+        value,
+      ]);
+    } else {
+      return new AnimatedDebug(message, adapt(value));
+    }
+  }
+  // Debugging is disabled in PROD
+  return value;
 }

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -61,7 +61,7 @@ function sanitizeArgMapping(argMapping) {
       typeof Proxy === 'function'
         ? new Proxy({}, proxyHandler)
         : createEventObjectProxyPolyfill();
-    alwaysNodes.push(new AnimatedAlways(ev(proxy)));
+    alwaysNodes.push(createAnimatedAlways(ev(proxy)));
     traverse(proxy, []);
   }
 

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -3,7 +3,7 @@ import ReanimatedModule from '../ReanimatedModule';
 
 import AnimatedNode from './AnimatedNode';
 import InternalAnimatedValue from './AnimatedValue';
-import AnimatedAlways from './AnimatedAlways';
+import { createAnimatedAlways } from './AnimatedAlways';
 
 import invariant from 'fbjs/lib/invariant';
 import createEventObjectProxyPolyfill from './createEventObjectProxyPolyfill';
@@ -21,7 +21,7 @@ function sanitizeArgMapping(argMapping) {
       eventMappings.push(path.concat(value.__val.__nodeID));
     } else if (typeof value === 'function') {
       const node = new InternalAnimatedValue(0);
-      alwaysNodes.push(new AnimatedAlways(value(node)));
+      alwaysNodes.push(createAnimatedAlways(value(node)));
       eventMappings.push(path.concat(node.__nodeID));
     } else if (typeof value === 'object') {
       for (const key in value) {

--- a/src/core/AnimatedEvent.js
+++ b/src/core/AnimatedEvent.js
@@ -2,7 +2,7 @@ import { findNodeHandle } from 'react-native';
 import ReanimatedModule from '../ReanimatedModule';
 
 import AnimatedNode from './AnimatedNode';
-import AnimatedValue from './AnimatedValue';
+import InternalAnimatedValue from './AnimatedValue';
 import AnimatedAlways from './AnimatedAlways';
 
 import invariant from 'fbjs/lib/invariant';
@@ -15,12 +15,12 @@ function sanitizeArgMapping(argMapping) {
   const alwaysNodes = [];
 
   const traverse = (value, path) => {
-    if (value instanceof AnimatedValue) {
+    if (value instanceof InternalAnimatedValue) {
       eventMappings.push(path.concat(value.__nodeID));
     } else if (typeof value === 'object' && value.__val) {
       eventMappings.push(path.concat(value.__val.__nodeID));
     } else if (typeof value === 'function') {
-      const node = new AnimatedValue(0);
+      const node = new InternalAnimatedValue(0);
       alwaysNodes.push(new AnimatedAlways(value(node)));
       eventMappings.push(path.concat(node.__nodeID));
     } else if (typeof value === 'object') {
@@ -98,4 +98,8 @@ export default class AnimatedEvent extends AnimatedNode {
     ReanimatedModule.detachEvent(viewTag, eventName, this.__nodeID);
     this.__detach();
   }
+}
+
+export function createAnimatedEvent(argMapping, config) {
+  return new AnimatedEvent(argMapping, config);
 }

--- a/src/core/AnimatedOperator.js
+++ b/src/core/AnimatedOperator.js
@@ -1,7 +1,8 @@
 import AnimatedNode from './AnimatedNode';
-import { val } from '../utils';
+import { val } from '../val';
 
 import invariant from 'fbjs/lib/invariant';
+import { adapt } from '../core/AnimatedBlock';
 
 function reduce(fn) {
   return input => input.reduce((a, b) => fn(val(a), val(b)));
@@ -70,4 +71,8 @@ export default class AnimatedOperator extends AnimatedNode {
     }
     return this._operation(this._input);
   }
+}
+
+export function createAnimatedOperator(name) {
+  return (...args) => new AnimatedOperator(name, args.map(adapt));
 }

--- a/src/core/AnimatedOperator.js
+++ b/src/core/AnimatedOperator.js
@@ -50,7 +50,7 @@ const OPERATIONS = {
   neq: infix((a, b) => a != b),
 };
 
-export default class AnimatedOperator extends AnimatedNode {
+class AnimatedOperator extends AnimatedNode {
   _input;
   _op;
   _operation;

--- a/src/core/AnimatedSet.js
+++ b/src/core/AnimatedSet.js
@@ -2,7 +2,7 @@ import AnimatedNode from './AnimatedNode';
 import { val } from '../val';
 import { adapt } from '../core/AnimatedBlock';
 
-export default class AnimatedSet extends AnimatedNode {
+class AnimatedSet extends AnimatedNode {
   _what;
   _value;
 

--- a/src/core/AnimatedSet.js
+++ b/src/core/AnimatedSet.js
@@ -1,5 +1,6 @@
 import AnimatedNode from './AnimatedNode';
-import { val } from '../utils';
+import { val } from '../val';
+import { adapt } from '../core/AnimatedBlock';
 
 export default class AnimatedSet extends AnimatedNode {
   _what;
@@ -16,4 +17,8 @@ export default class AnimatedSet extends AnimatedNode {
     this._what._updateValue(newValue);
     return newValue;
   }
+}
+
+export function createAnimatedSet(what, value) {
+  return new AnimatedSet(what, adapt(value));
 }

--- a/src/core/AnimatedStartClock.js
+++ b/src/core/AnimatedStartClock.js
@@ -19,3 +19,7 @@ export default class AnimatedStartClock extends AnimatedNode {
     return 0;
   }
 }
+
+export function createAnimatedStartClock(clock) {
+  return new AnimatedStartClock(clock);
+}

--- a/src/core/AnimatedStartClock.js
+++ b/src/core/AnimatedStartClock.js
@@ -2,7 +2,7 @@ import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
 import invariant from 'fbjs/lib/invariant';
 
-export default class AnimatedStartClock extends AnimatedNode {
+class AnimatedStartClock extends AnimatedNode {
   _clockNode;
 
   constructor(clockNode) {

--- a/src/core/AnimatedStopClock.js
+++ b/src/core/AnimatedStopClock.js
@@ -19,3 +19,7 @@ export default class AnimatedStopClock extends AnimatedNode {
     return 0;
   }
 }
+
+export function createAnimatedStopClock(clock) {
+  return new AnimatedStopClock(clock);
+}

--- a/src/core/AnimatedStopClock.js
+++ b/src/core/AnimatedStopClock.js
@@ -2,7 +2,7 @@ import AnimatedNode from './AnimatedNode';
 import AnimatedClock from './AnimatedClock';
 import invariant from 'fbjs/lib/invariant';
 
-export default class AnimatedStopClock extends AnimatedNode {
+class AnimatedStopClock extends AnimatedNode {
   _clockNode;
 
   constructor(clockNode) {

--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -1,56 +1,9 @@
-import AnimatedNode from './AnimatedNode';
-import { set } from '../base';
-import { val } from '../utils';
-import { evaluateOnce } from '../derived/evaluateOnce';
+import { createAnimatedSet as set } from '../core/AnimatedSet';
 import interpolate from '../derived/interpolate';
-import ReanimatedModule from '../ReanimatedModule';
+import InternalAnimatedValue from './InternalAnimatedValue';
+import { evaluateOnce } from '../derived/evaluateOnce';
 
-function sanitizeValue(value) {
-  return value === null || value === undefined || typeof value === 'string'
-    ? value
-    : Number(value);
-}
-
-export default class AnimatedValue extends AnimatedNode {
-  constructor(value) {
-    super({ type: 'value', value: sanitizeValue(value) });
-    this._startingValue = this._value = value;
-    this._animation = null;
-  }
-
-  __detach() {
-    ReanimatedModule.getValue(
-      this.__nodeID,
-      val => (this.__nodeConfig.value = val)
-    );
-    this.__detachAnimation(this._animation);
-    super.__detach();
-  }
-
-  __detachAnimation(animation) {
-    animation && animation.__detach();
-    if (this._animation === animation) {
-      this._animation = null;
-    }
-  }
-
-  __attachAnimation(animation) {
-    this.__detachAnimation(this._animation);
-    this._animation = animation;
-  }
-
-  __onEvaluate() {
-    if (this.__inputNodes && this.__inputNodes.length) {
-      this.__inputNodes.forEach(val);
-    }
-    return this._value + this._offset;
-  }
-
-  _updateValue(value) {
-    this._value = value;
-    this.__forceUpdateCache(value);
-  }
-
+export default class AnimatedValue extends InternalAnimatedValue {
   setValue(value) {
     this.__detachAnimation(this._animation);
     evaluateOnce(set(this, value), this);

--- a/src/core/AnimatedValue.js
+++ b/src/core/AnimatedValue.js
@@ -3,6 +3,7 @@ import interpolate from '../derived/interpolate';
 import InternalAnimatedValue from './InternalAnimatedValue';
 import { evaluateOnce } from '../derived/evaluateOnce';
 
+// Animated value wrapped with extra methods for omit cycle of dependencies
 export default class AnimatedValue extends InternalAnimatedValue {
   setValue(value) {
     this.__detachAnimation(this._animation);

--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -1,0 +1,54 @@
+import AnimatedNode from './AnimatedNode';
+import { val } from '../val';
+import ReanimatedModule from '../ReanimatedModule';
+
+function sanitizeValue(value) {
+  return value === null || value === undefined || typeof value === 'string'
+    ? value
+    : Number(value);
+}
+
+/**
+ * This class has been made internal in order to omit dependencies' cycles which
+ * were caused by imperative setValue and interpolate – they are currently exposed with AnimatedValue.js
+ */
+export default class InternalAnimatedValue extends AnimatedNode {
+  constructor(value) {
+    super({ type: 'value', value: sanitizeValue(value) });
+    this._startingValue = this._value = value;
+    this._animation = null;
+  }
+
+  __detach() {
+    ReanimatedModule.getValue(
+      this.__nodeID,
+      val => (this.__nodeConfig.value = val)
+    );
+    this.__detachAnimation(this._animation);
+    super.__detach();
+  }
+
+  __detachAnimation(animation) {
+    animation && animation.__detach();
+    if (this._animation === animation) {
+      this._animation = null;
+    }
+  }
+
+  __attachAnimation(animation) {
+    this.__detachAnimation(this._animation);
+    this._animation = animation;
+  }
+
+  __onEvaluate() {
+    if (this.__inputNodes && this.__inputNodes.length) {
+      this.__inputNodes.forEach(val);
+    }
+    return this._value + this._offset;
+  }
+
+  _updateValue(value) {
+    this._value = value;
+    this.__forceUpdateCache(value);
+  }
+}

--- a/src/derived/acc.js
+++ b/src/derived/acc.js
@@ -1,5 +1,5 @@
 import { set, add } from '../base';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 
 export default function acc(v) {
   const acc = new AnimatedValue(0);

--- a/src/derived/diff.js
+++ b/src/derived/diff.js
@@ -1,5 +1,5 @@
 import { cond, block, defined, sub, set } from '../base';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 
 export default function diff(v) {
   const stash = new AnimatedValue(0);

--- a/src/derived/diffClamp.js
+++ b/src/derived/diffClamp.js
@@ -1,5 +1,5 @@
 import { cond, defined, set, add } from '../base';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 import min from './min';
 import max from './max';
 import diff from './diff';

--- a/src/derived/evaluateOnce.js
+++ b/src/derived/evaluateOnce.js
@@ -1,5 +1,8 @@
-import AnimatedValue from '../core/AnimatedValue';
-import { call, always, cond, set } from '../base';
+import AnimatedValue from '../core/InternalAnimatedValue';
+import { createAnimatedSet as set } from '../core/AnimatedSet';
+import { createAnimatedCall as call } from '../core/AnimatedCall';
+import { createAnimatedAlways as always } from '../core/AnimatedAlways';
+import { createAnimatedCond as cond } from '../core/AnimatedCond';
 
 /**
  * evaluate given node and notify children
@@ -7,6 +10,7 @@ import { call, always, cond, set } from '../base';
  * @param input - nodes (or one node) representing values which states input for node.
  * @param callback - after callback
  */
+
 export function evaluateOnce(node, input = [], callback) {
   if (!Array.isArray(input)) {
     input = [input];

--- a/src/derived/interpolate.js
+++ b/src/derived/interpolate.js
@@ -1,12 +1,13 @@
 import {
-  cond,
   lessThan,
   multiply,
   sub,
   add,
   divide,
   greaterThan,
-} from '../base';
+} from '../operators';
+
+import { createAnimatedCond as cond } from '../core/AnimatedCond';
 import invariant from 'fbjs/lib/invariant';
 import AnimatedNode from '../core/AnimatedNode';
 

--- a/src/derived/max.js
+++ b/src/derived/max.js
@@ -1,5 +1,5 @@
 import { cond, lessThan } from '../base';
-import { adapt } from '../utils';
+import { adapt } from '../core/AnimatedBlock';
 
 export default function max(a, b) {
   a = adapt(a);

--- a/src/derived/min.js
+++ b/src/derived/min.js
@@ -1,5 +1,5 @@
 import { cond, lessThan } from '../base';
-import { adapt } from '../utils';
+import { adapt } from '../core/AnimatedBlock';
 
 export default function min(a, b) {
   a = adapt(a);

--- a/src/derived/onChange.js
+++ b/src/derived/onChange.js
@@ -1,5 +1,5 @@
 import { block, cond, defined, neq, not, set } from '../base';
-import AnimatedValue from '../core/AnimatedValue';
+import AnimatedValue from '../core/InternalAnimatedValue';
 
 export default function onChange(value, action) {
   const prevValue = new AnimatedValue();

--- a/src/operators.js
+++ b/src/operators.js
@@ -1,0 +1,25 @@
+import { createAnimatedOperator } from './core/AnimatedOperator';
+
+const operator = createAnimatedOperator;
+
+export const add = operator('add');
+export const sub = operator('sub');
+export const multiply = operator('multiply');
+export const divide = operator('divide');
+export const pow = operator('pow');
+export const modulo = operator('modulo');
+export const sqrt = operator('sqrt');
+export const sin = operator('sin');
+export const cos = operator('cos');
+export const exp = operator('exp');
+export const round = operator('round');
+export const lessThan = operator('lessThan');
+export const eq = operator('eq');
+export const greaterThan = operator('greaterThan');
+export const lessOrEq = operator('lessOrEq');
+export const greaterOrEq = operator('greaterOrEq');
+export const neq = operator('neq');
+export const and = operator('and');
+export const or = operator('or');
+export const defined = operator('defined');
+export const not = operator('not');

--- a/src/operators.js
+++ b/src/operators.js
@@ -23,3 +23,7 @@ export const and = operator('and');
 export const or = operator('or');
 export const defined = operator('defined');
 export const not = operator('not');
+export const tan = operator('tan');
+export const acos = operator('acos');
+export const asin = operator('asin');
+export const atan = operator('atan');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,24 +1,3 @@
 import AnimatedBlock from './core/AnimatedBlock';
 import AnimatedNode from './core/AnimatedNode';
-import AnimatedValue from './core/AnimatedValue';
-
-function nodify(v) {
-  if (typeof v === 'object' && v.__isProxy) {
-    if (!v.__val) {
-      v.__val = new AnimatedValue(0);
-    }
-    return v.__val;
-  }
-  // TODO: cache some typical static values (e.g. 0, 1, -1)
-  return v instanceof AnimatedNode ? v : new AnimatedValue(v);
-}
-
-export function adapt(v) {
-  return Array.isArray(v)
-    ? new AnimatedBlock(v.map(node => adapt(node)))
-    : nodify(v);
-}
-
-export function val(v) {
-  return v && v.__getValue ? v.__getValue() : v || 0;
-}
+import InternalAnimatedValue from './core/AnimatedValue';

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,0 @@
-import AnimatedBlock from './core/AnimatedBlock';
-import AnimatedNode from './core/AnimatedNode';
-import InternalAnimatedValue from './core/AnimatedValue';

--- a/src/val.js
+++ b/src/val.js
@@ -1,0 +1,3 @@
+export function val(v) {
+  return v && v.__getValue ? v.__getValue() : v || 0;
+}


### PR DESCRIPTION
The main problems were with `setValue` and `interpolate` so I made them not available internally and exposed it with addition class. In internal operation `InternalAnimatedValue` is used and it's not causing dependencies' cycles.

Changed logic of exposing nodes. Now there's no need to import whole `base.js` for wrapped nodes. 