### PR TITLE
Add additional check for running clock for imperative snapTo

### DIFF
--- a/Example/Interactable.js
+++ b/Example/Interactable.js
@@ -429,6 +429,7 @@ class Interactable extends Component {
           cond(dt, dragBehaviors[axis]),
         ],
         [
+          cond(clockRunning(clock), 0, startClock(clock)),
           cond(dragging, [updateSnapTo, set(dragging, 0)]),
           cond(dt, snapBehaviors[axis]),
           testMovementFrames,


### PR DESCRIPTION
## Motivation
Issue has been described here https://github.com/kmagiera/react-native-reanimated/issues/182

Using imperative snapTo in `Interactable.View` sometimes didn't lead to any effect. 

## Changes
It was caused by a fact that clock was not running and therefore changes haven't been evaluated properly. If GH responsible for dragging hadn't beed activated, clock was not running and then snapping without dragging was expected to run  with clock stopped. 

Added extra condition for it.