### PR TITLE
Allow call's input to be a string on Android

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/JSCallNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/JSCallNode.java
@@ -19,12 +19,17 @@ public class JSCallNode extends Node {
   @Override
   protected Double evaluate() {
     WritableArray args = Arguments.createArray();
-    for (int i = 0; i < mInputIDs.length; i++) {
-      Node node = mNodesManager.findNodeById(mInputIDs[i], Node.class);
+    for (int mInputID : mInputIDs) {
+      Node node = mNodesManager.findNodeById(mInputID, Node.class);
       if (node.value() == null) {
         args.pushNull();
       } else {
-        args.pushDouble(node.doubleValue());
+        Object value = node.value();
+        if (value instanceof String) {
+          args.pushString((String) value);
+        } else {
+          args.pushDouble(node.doubleValue());
+        }
       }
     }
     WritableMap eventData = Arguments.createMap();

--- a/android/src/main/java/com/swmansion/reanimated/nodes/JSCallNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/JSCallNode.java
@@ -19,8 +19,8 @@ public class JSCallNode extends Node {
   @Override
   protected Double evaluate() {
     WritableArray args = Arguments.createArray();
-    for (int mInputID : mInputIDs) {
-      Node node = mNodesManager.findNodeById(mInputID, Node.class);
+    for (int i = 0; i < mInputIDs.length; i++) {
+      Node node = mNodesManager.findNodeById(mInputIDs[i], Node.class);
       if (node.value() == null) {
         args.pushNull();
       } else {


### PR DESCRIPTION
## Motivation
On Android JSCall exception is thrown type of node's value was string

## Changes
Added condition for checking if type of node is a string and then handle it properly. 