### PR TITLE
[TypeScript] "start" callback should be optional

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -80,7 +80,7 @@ declare module 'react-native-reanimated' {
       deceleration: Adaptable<number>;
     }
     export interface BackwardCompatibleWrapper {
-      start: (callback : (data: { finished: boolean }) => any) => void;
+      start: (callback? : (data: { finished: boolean }) => any) => void;
       stop: () => void;
     }
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -80,7 +80,7 @@ declare module 'react-native-reanimated' {
       deceleration: Adaptable<number>;
     }
     export interface BackwardCompatibleWrapper {
-      start: (callback? : (data: { finished: boolean }) => any) => void;
+      start: (callback?: (data: { finished: boolean }) => any) => void;
       stop: () => void;
     }
 


### PR DESCRIPTION
This PR allows using `.start()` without passing a callback to it (like `Animated` from `react-native` does 😅).