### PR TITLE
Add Animated.useCode hook as an alternative to Animated.Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ block([
 }/>
 ```
 
+## `Animated.useCode`
+
+The `useCode` hook acts as an alternative to the `Animated.Code` component.
+```js
+Animated.useCode(node, deps)
+```
+It's passed an animated node and an array of dependencies, and updates that node both when the component mounts and every time a value in that array changes. It does nothing on versions of React Native that don't support hooks (<0.59).
+```js
+const [offset, setOffset] = React.useState(20);
+Animated.useCode(
+  set(transX1, add(_transX, offset)),
+  [offset]
+);
+```
+
 ## Event handling with reanimated nodes
 
 `react-native-reanimated`'s new syntax is possible to be used with `Animated.event`. Instead of providing only a mapping from event fields to animated nodes, it is allowed to write a function that takes reanimated values map as an input and return a block (or any other reanimated function) that will be then used to handle the event.

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -278,6 +278,12 @@ declare module 'react-native-reanimated' {
       config: DecayConfig,
     ): BackwardCompatibleWrapper;
 
+    // hooks
+    export function useCode(
+      exec: AnimatedNode<number>,
+      deps: Array<any>,
+    ): void
+
     // configuration
 
     // `addWhitelistedNativeProps` will likely be removed soon, and so is

--- a/src/derived/index.js
+++ b/src/derived/index.js
@@ -9,3 +9,4 @@ export { default as min } from './min';
 export { default as onChange } from './onChange';
 export { default as floor } from './floor';
 export { default as ceil } from './ceil';
+export { default as useCode } from './useCode';

--- a/src/derived/useCode.js
+++ b/src/derived/useCode.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { always } from '../base';
+
+function useCode(exec, deps) {
+  if (typeof React.useEffect === 'function') {
+    React.useEffect(() => {
+      const animatedAlways = always(exec);
+      animatedAlways.__attach();
+      return () => {
+        animatedAlways.__detach();
+      };
+    }, deps);
+  }
+}
+export default useCode;


### PR DESCRIPTION
I'm not sure about the current stance on adding hooks to `react-native-reanimated`, but this adds an `Animated.useCode` hook with an API halfway between `useEffect` and `Animated.Code`, that serves as an alternative to `Animated.Code`. Instead of passing in a callback, the user passes in a reanimated node to execute, along with an array of dependencies. Since we use `useEffect` under the hood, any change in the dependency array also causes the node to be updated.

One piece of behavior that I'm still iffy on is what happens if a dependency array isn't passed in. The idea is that one is always passed in (the typings reflect this), but right now, not passing one in causes the node to be re-run on every render. I think this is expected enough that we can leave it as is.

Also, this is kind of obvious, but `Animated.useCode` is a no-op on a version of RN without hooks.