### PR TITLE
Better error messages when using Animated.Code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,6 @@ module.exports = {
   rules: {
     'import/no-unresolved': 2,
     'react/jsx-uses-vars': 2,
+    'react/jsx-uses-react': 2,
   },
 };

--- a/src/Animated.js
+++ b/src/Animated.js
@@ -1,13 +1,4 @@
-import {
-  Image,
-  ScrollView,
-  Text,
-  View,
-  UIManager,
-  requireNativeComponent,
-  findNodeHandle,
-} from 'react-native';
-import React from 'react';
+import { Image, ScrollView, Text, View } from 'react-native';
 import Easing from './Easing';
 import AnimatedClock from './core/AnimatedClock';
 import AnimatedValue from './core/AnimatedValue';

--- a/src/core/AnimatedCode.js
+++ b/src/core/AnimatedCode.js
@@ -1,11 +1,39 @@
 import React from 'react';
 import AnimatedAlways from './AnimatedAlways';
+import AnimatedNode from './AnimatedNode';
 
 class Code extends React.Component {
+  static resolveNode = maybeNode => {
+    if (typeof maybeNode === 'function') {
+      return Code.resolveNode(maybeNode());
+    }
+
+    if (maybeNode instanceof AnimatedNode) {
+      return maybeNode;
+    }
+
+    return null;
+  };
+
   componentDidMount() {
-    this.always = new AnimatedAlways(
-      this.props.exec ? this.props.exec : this.props.children()
-    );
+    const { children, exec } = this.props;
+    const nodeChildren = Code.resolveNode(children);
+    const nodeExec = Code.resolveNode(exec);
+
+    const cantResolveNode = nodeChildren === null && nodeExec === null;
+
+    if (cantResolveNode) {
+      const error =
+        nodeChildren === null
+          ? `Got "${typeof children}" type passed to children`
+          : `Got "${typeof exec}" type passed to exec`;
+
+      throw new Error(
+        `<Animated.Code /> expects the 'exec' prop or children to be an animated node or a function returning an animated node. ${error}`
+      );
+    }
+
+    this.always = new AnimatedAlways(nodeExec || nodeChildren);
     this.always.__attach();
   }
 

--- a/src/core/Core.test.js
+++ b/src/core/Core.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Animated from '../Animated';
+
+import renderer from 'react-test-renderer';
+
+jest.mock('../ReanimatedEventEmitter');
+jest.mock('../ReanimatedModule');
+
+describe('Core Animated components', () => {
+  it('fails if something other then a node or function that returns a node is passed to Animated.Code exec prop', () => {
+    console.error = jest.fn();
+
+    expect(() =>
+      renderer.create(<Animated.Code exec="not a node" />)
+    ).toThrowError(
+      "<Animated.Code /> expects the 'exec' prop or children to be an animated node or a function returning an animated node."
+    );
+  });
+
+  it('fails if something other then a node or function that returns a node is passed to Animated.Code children', () => {
+    console.error = jest.fn();
+
+    expect(() =>
+      renderer.create(<Animated.Code>not a node</Animated.Code>)
+    ).toThrowError(
+      "<Animated.Code /> expects the 'exec' prop or children to be an animated node or a function returning an animated node."
+    );
+  });
+});


### PR DESCRIPTION
Added improved error messages to Animated.Code when wrong props are passed to the component. Also, unified the types both the exec and children can accept. Both `exec` and `children` can now accept a node or a function returning a node.

Example:
```
const node = block([...]);
const nodeFn = () => node;
// All of the following lines are now valid
<Animated.Code exec={node} />
<Animated.Code exec={nodeFn} />
<Animated.Code>{node}</Animated.Code>
<Animated.Code>{nodeFn}</Animated.Code>
```

I've created some tests to assert the error is being thrown when wrong prop types are provided. I've create a separate suite for testing Animated* components. I'm not really skilled in writing tests so this might be wrong. 

Also, I've added the `jsx-uses-react` eslint rule to prevent false negatives when React is imported without using it directly, as JSX is using React implicitly. More info here: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md