### PR TITLE
Add numbers and non-node values to concat type

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -192,9 +192,9 @@ declare module 'react-native-reanimated' {
       sourceNode: Adaptable<number>,
     ): AnimatedNode<number>;
     export function concat(
-      a: AnimatedNode<string>,
-      b: AnimatedNode<string>,
-      ...others: AnimatedNode<string>[],
+      a: Adaptable<string> | Adaptable<number>,
+      b: Adaptable<string> | Adaptable<number>,
+      ...others: Array<Adaptable<string> | Adaptable<number>>,
     ): AnimatedNode<string>;
     export function cond(
       conditionNode: Adaptable<number>,


### PR DESCRIPTION
The TS type signature for `concat` only allows string nodes right now, but it should also allow number nodes, JS string values, and JS number values, e.g.
```typescript
set(rotateX, concat(translateY, "deg"))
```
This PR changes the instances of `AnimatedNode<string>` in `concat`'s parameter types to `Adaptable<string> | Adaptable<number>`. This works since we internally run `adapt` on the arguments of `concat`.