### PR TITLE
Convert CATransform3d using [NSValue valueWithCATransform3D]

### DIFF
--- a/ios/Transitioning/REAAllTransitions.m
+++ b/ios/Transitioning/REAAllTransitions.m
@@ -150,8 +150,8 @@
     case REATransitionAnimationTypeScale: {
       CATransform3D finalTransform = view.layer.transform;
       animation = [CABasicAnimation animationWithKeyPath:@"transform"];
-      animation.fromValue = @(CATransform3DMakeScale(0, 0, 0));
-      animation.toValue = @(finalTransform);
+      animation.fromValue = [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.0, 0.0, 0)];
+      animation.toValue = [NSValue valueWithCATransform3D:finalTransform];
       break;
     }
     case REATransitionAnimationTypeSlideTop:
@@ -224,8 +224,8 @@
       CATransform3D fromValue = snapshot.transform;
       snapshot.transform = CATransform3DMakeScale(0.001, 0.001, 0.001);
       animation = [CABasicAnimation animationWithKeyPath:@"transform"];
-      animation.fromValue = @(fromValue);
-      animation.toValue = @(CATransform3DMakeScale(0.001, 0.001, 0.001));
+      animation.fromValue = [NSValue valueWithCATransform3D:fromValue];
+      animation.toValue = [NSValue valueWithCATransform3D:CATransform3DMakeScale(0.001, 0.001, 0.001)];
       break;
     }
     case REATransitionAnimationTypeSlideTop:


### PR DESCRIPTION
Converting a type with boxed constraints caused `Illegal type 'CATransform3D' (aka 'struct CATransform3D') used in a boxed expression`.

Thanks @sochalewski for the tip.

Fixes #236 