### PR TITLE
📚Minor documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,19 +612,19 @@ Evaluates the given node and returns an absolute value of the node's value.
 ### `min`
 
 ```js
-min(nodeOrValue1, ...)
+min(nodeOrValue1, nodeOrValue2)
 ```
 
-Takes one or more nodes as an input and returns a minimum of all the node's values.
+Takes two nodes as an input and returns a minimum of all the node's values.
 
 ---
 ### `max`
 
 ```js
-max(nodeOrValue1, ...)
+max(nodeOrValue1, nodeOrValue2)
 ```
 
-Takes one or more nodes as an input and returns a maximum of all the node's values.
+Takes two nodes as an input and returns a maximum of all the node's values.
 
 ---
 ### `diff`


### PR DESCRIPTION
This might have been fixed in a newer version of reanimated (I'm using the version shipped with expo32) but currently `min` and `max` only accept exactly two arguments.