### PR TITLE
Fix example app's metro config on windows machines

### DIFF
--- a/Example/metro.config.js
+++ b/Example/metro.config.js
@@ -6,8 +6,8 @@ const glob = require('glob-to-regexp');
 
 function getBlacklist() {
   const nodeModuleDirs = [
-    glob(`${path.resolve(__dirname, '..')}/node_modules/*`),
-    glob(`${path.resolve(__dirname)}/node_modules/metro/node_modules/fbjs/*`),
+    glob(`${process.platform === 'win32' ? path.resolve(__dirname, '..').replace(/\\/g, '/') : path.resolve(__dirname, '..')}/node_modules/*`),
+    glob(`${process.platform === 'win32' ? path.resolve(__dirname).replace(/\\/g, '/') : path.resolve(__dirname)}/node_modules/metro/node_modules/fbjs/*`),
   ];
   return blacklist(nodeModuleDirs);
 }


### PR DESCRIPTION
glob-to-regexp does not [escape backslash as of version 0.4](https://github.com/fitzgen/glob-to-regexp/pull/13) which causes issues on windows machines because path.resolve value contains backslashes. replacing backslashes with slashes only on windows machines fixes the issue.

Here's the resulting regular expressions produced by glob-to-regexp **before** making changes:

```
/^C:\Users\sjjd\Documents\Repos\Official\react-native-reanimated\/node_modules\/.*$/
/^C:\Users\sjjd\Documents\Repos\Official\react-native-reanimated\Example\/node_modules\/metro\/node_modules\/fbjs\/.*$/
```

Here's the resulting regular expressions produced by glob-to-regexp **after** making changes:

```
/^C:\/Users\/sjjd\/Documents\/Repos\/Official\/react-native-reanimated\/node_modules\/.*$/
/^C:\/Users\/sjjd\/Documents\/Repos\/Official\/react-native-reanimated\/Example\/node_modules\/metro\/node_modules\/fbjs\/.*$/
```