### PR TITLE
Add a mock implementation for test runners

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -1,0 +1,121 @@
+/**
+ * Mock implementation for test runners.
+ *
+ * Example:
+ *
+ * ```js
+ * jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
+ * ```
+ */
+
+const React = require('react');
+const { View, Text, Image, ScrollView } = require('react-native');
+
+const NOOP = () => undefined;
+
+class Code extends React.Component {
+  static resolveNode = () => null;
+
+  render() {
+    return null;
+  }
+}
+
+module.exports = {
+  __esModule: true,
+
+  default: {
+    SpringUtils: {
+      makeDefaultConfig: NOOP,
+      makeConfigFromBouncinessAndSpeed: NOOP,
+      makeConfigFromOrigamiTensionAndFriction: NOOP,
+    },
+
+    View,
+    Text,
+    Image,
+    ScrollView,
+    Code,
+
+    Clock: NOOP,
+    Node: NOOP,
+    Value: NOOP,
+
+    Extrapolate: {
+      EXTEND: 'extend',
+      CLAMP: 'clamp',
+      IDENTITY: 'identity',
+    },
+
+    add: NOOP,
+    sub: NOOP,
+    multiply: NOOP,
+    divide: NOOP,
+    pow: NOOP,
+    modulo: NOOP,
+    sqrt: NOOP,
+    sin: NOOP,
+    cos: NOOP,
+    tan: NOOP,
+    acos: NOOP,
+    asin: NOOP,
+    atan: NOOP,
+    exp: NOOP,
+    round: NOOP,
+    floor: NOOP,
+    ceil: NOOP,
+    lessThan: NOOP,
+    eq: NOOP,
+    greaterThan: NOOP,
+    lessOrEq: NOOP,
+    greaterOrEq: NOOP,
+    neq: NOOP,
+    and: NOOP,
+    or: NOOP,
+    defined: NOOP,
+    not: NOOP,
+    set: NOOP,
+    concat: NOOP,
+    cond: NOOP,
+    block: NOOP,
+    call: NOOP,
+    debug: NOOP,
+    onChange: NOOP,
+    startClock: NOOP,
+    stopClock: NOOP,
+    clockRunning: NOOP,
+    event: NOOP,
+    abs: NOOP,
+    acc: NOOP,
+    color: NOOP,
+    diff: NOOP,
+    diffClamp: NOOP,
+    interpolate: NOOP,
+    max: NOOP,
+    min: NOOP,
+
+    decay: NOOP,
+    timing: NOOP,
+    spring: NOOP,
+
+    useCode: NOOP,
+  },
+
+  Easing: {
+    linear: NOOP,
+    ease: NOOP,
+    quad: NOOP,
+    cubic: NOOP,
+    poly: () => NOOP,
+    sin: NOOP,
+    circle: NOOP,
+    exp: NOOP,
+    elastic: () => NOOP,
+    back: () => NOOP,
+    bounce: () => NOOP,
+    bezier: () => NOOP,
+    in: () => NOOP,
+    out: () => NOOP,
+    inOut: () => NOOP,
+  },
+};

--- a/mock.js
+++ b/mock.js
@@ -14,8 +14,6 @@ const { View, Text, Image, ScrollView } = require('react-native');
 const NOOP = () => undefined;
 
 class Code extends React.Component {
-  static resolveNode = () => null;
-
   render() {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "ios/",
     "RNReanimated.podspec",
     "README.md",
-    "react-native-reanimated.d.ts"
+    "react-native-reanimated.d.ts",
+    "mock.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was recently using reanimated in react-navigation where I needed to mock it to be able to run it in Jest. It'll be great if the mock was in the library so we don't have to duplicate it in every project.

I looked through the typescript definitions and added a mock function for almost everything. I didn't use anything specific to a test runner such as Jest, so it should be possible to use the mock with any test runner.