### PR TITLE
Add CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,5 +59,5 @@ matrix:
     - export PRODUCT_BUNDLE_IDENTIFIER="org.reactjs.native.example.ReanimatedExample"
 
     script:
-    - xcodebuild -project ./ios/ReanimatedExample.xcodeproj -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build
+    - xcodebuild -project ./ios/ReanimatedExample.xcodeproj -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build -UseModernBuildSystem=NO
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,63 @@
+matrix:
+  include:
+  - language: android
+    sudo: required
+    jdk: oraclejdk8
+    env: NODE_VERSION=10.15.3
+    before_cache:
+    - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+    - rm -rf $HOME/.gradle/caches/*/plugin-resolution/
+    cache:
+      directories:
+      - $HOME/.yarn-cache
+      - $HOME/.gradle/caches/
+      - $HOME/.gradle/wrapper/
+    android:
+      components:
+      - tools
+      - platform-tools
+      - build-tools-27.0.3
+
+    install:
+    - yes | sdkmanager "platforms;android-27"
+    - nvm install $NODE_VERSION
+    - nvm use $NODE_VERSION
+    - nvm alias default $NODE_VERSION
+    - node --version
+    - npm install -g yarn --ignore-dependencies
+    - npm install -g react-native-cli
+    - cd Example
+    - yarn
+
+    script:
+    - cd ./android && ./gradlew assembleDebug
+
+  - language: objective-c
+    osx_image: xcode10.2
+    xcode_sdk: iphonesimulator12.2
+    xcode_destination: platform=iOS Simulator,OS=12.2,name=iPhone X
+    env: NODE_VERSION=10.15.3
+
+    branches:
+      only:
+      - master
+
+    cache: yarn
+
+    install:
+    - nvm --version
+    - echo $NODE_VERSION
+    - sudo launchctl limit maxfiles 2048 unlimited
+    - sudo ulimit -n 10000
+    - nvm install $NODE_VERSION
+    - nvm use $NODE_VERSION
+    - nvm alias default $NODE_VERSION
+    - brew install yarn --ignore-dependencies
+    - npm install -g react-native-cli
+    - cd Example
+    - yarn
+    - export PRODUCT_BUNDLE_IDENTIFIER="org.reactjs.native.example.ReanimatedExample"
+
+    script:
+    - xcodebuild -project ./ios/ReanimatedExample.xcodeproj -scheme ReanimatedExample -configuration Debug -sdk iphonesimulator -derivedDataPath ./ios/build
+


### PR DESCRIPTION
# Motivation
In React Native Gesture Handler repo we have integration with travisCI to test if our Example apps are building and some detox e2e tests on iOS. I thought that it is not much work to add CI here as we already have config and project config is similar so it would most likely work out of the box with little tweaks.

# Changes
Added yaml config file and travis CI integration