### PR TITLE
Remove react/react-native peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,6 @@
   },
   "homepage": "https://github.com/kmagiera/react-native-reanimated#readme",
   "dependencies": {},
-  "peerDependencies": {
-    "react": "16.0.0-alpha.6",
-    "react-native": "^0.44.1"
-  },
   "devDependencies": {
     "babel-eslint": "^8.2.3",
     "babel-jest": "23.0.1",


### PR DESCRIPTION
We're not keeping these up to date and realistically nobody is going to install this library without having both react and react-native, so there's not much of a point in keeping these here. Also they create warnings when running `yarn` in a new `expo` project.