### PR TITLE
Get rid of Bezier's arguments check

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/nodes/BezierNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/BezierNode.java
@@ -15,13 +15,7 @@ public class BezierNode extends Node {
     protected PointF b = new PointF();
     protected PointF c = new PointF();
 
-    public CubicBezierInterpolator(PointF start, PointF end) throws IllegalArgumentException {
-      if (start.x < 0 || start.x > 1) {
-        throw new IllegalArgumentException("startX value must be in the range [0, 1]");
-      }
-      if (end.x < 0 || end.x > 1) {
-        throw new IllegalArgumentException("endX value must be in the range [0, 1]");
-      }
+    public CubicBezierInterpolator(PointF start, PointF end) {
       this.start = start;
       this.end = end;
     }

--- a/src/core/AnimatedBezier.js
+++ b/src/core/AnimatedBezier.js
@@ -64,10 +64,6 @@ function newtonRaphsonIterate(aX, aGuessT, mX1, mX2) {
 }
 
 function bezier(mX1, mY1, mX2, mY2) {
-  if (!(mX1 >= 0 && mX1 <= 1 && mX2 >= 0 && mX2 <= 1)) {
-    throw new Error('bezier x values must be in [0, 1] range');
-  }
-
   // Precompute samples table
   var sampleValues = float32ArraySupported
     ? new Float32Array(kSplineTableSize)


### PR DESCRIPTION
## Motivation
This check appears to be important in one issue. It guarantees that the function generated by a Bezier function is a surjection and is inspired by CSS on web. However, there are cases where it could be useful because it gives a wider range of parametrization. 

E.g.: 
``Easing.bezier(0.5, 0.3, -0.37, 1)`` leads to: 
![image](https://user-images.githubusercontent.com/25709300/59152274-ff766500-8a40-11e9-94d2-b1520ef26e85.png)
Which will be very useful while imitating this path:
http://androidxref.com/9.0.0_r3/xref/frameworks/base/core/res/res/interpolator/fast_out_extra_slow_in.xml

We want to add it in react-navigation 

## Changes
Nothing more but removing errors' throwing. 

