### PR TITLE
Bypass animation queue for onScroll events

### DIFF
--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -351,7 +351,14 @@
   static NSArray<NSString *> *directEventNames;
   static dispatch_once_t directEventNamesToken;
   dispatch_once(&directEventNamesToken, ^{
-    directEventNames = @[@"onScroll"];
+    directEventNames = @[
+      @"onContentSizeChange",
+      @"onMomentumScrollBegin",
+      @"onMomentumScrollEnd",
+      @"onScroll",
+      @"onScrollBeginDrag",
+      @"onScrollEndDrag"
+    ];
   });
   
   return [directEventNames containsObject:event.eventName];

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -371,6 +371,8 @@
 
   if (eventNode != nil) {
     if ([self isDirectEvent:event]) {
+      // Bypass the event queue/animation frames and process scroll events
+      // immediately to avoid getting out of sync with the scroll position
       [self processDirectEvent:event];
     } else {
       // enqueue node to be processed


### PR DESCRIPTION
This PR is a proof of concept on how to address issues like #160 #309. 

As outlined in [my comment](https://github.com/kmagiera/react-native-reanimated/issues/160#issuecomment-502143873), the problem with the current batched updates are that reanimated lags behind event processing by at least one event, in some cases up to 3-4. If using something like react-native-gesture-handler this is generally not noticeable as reanimated will be responsible for positioning all elements, but when deriving an animated value from a scroll event this would cause the elements positioned by reanimated to be out of sync with the scroll view. 

To address the lag, this PR introduces a concept of "direct events", that will bypass the queue and apply its effects immediately. Due to my unfamiliarity with the codebase I didn't really know how to do this in a nice way without also doing a quite big refactor. This is a low invasive change to illustrate how it can be addressed, I'm happy to receive feedback on how this can be done in a cleaner way. 

### Test plan
Using @lindesvard's reproduction of the issue https://github.com/lindesvard/reanimated-scroll-perf on a physical device, applying these changes should remove the lag and stuttering. 

### Adverse effects
* Since the direct effects will bypass the queue, it will not retain the same order. Given the declarative nature of reanimated I think this should be OK in most cases, but still worth mentioning. A possible workaround is to flush the queue before applying direct events. 
* The current way to determine direct events are by event name which is not particularly specific. In the odd case of naming collision, I don't see it having profound negative effects however. 