### PR TITLE
Fixed Typescript error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-reanimated",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "More powerful alternative to Animated library for React Native.",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -64,11 +64,11 @@ declare module 'react-native-reanimated' {
       right: Adaptable<number>
     ) => AnimatedNode<T>;
     type UnaryOperator = (value: Adaptable<number>) => AnimatedNode<number>;
-    type MultiOperator = (
+    type MultiOperator<T = number> = (
       a: Adaptable<number>,
       b: Adaptable<number>,
       ...others: Adaptable<number>[]
-    ) => AnimatedNode<number>;
+    ) => AnimatedNode<T>;
 
     export interface DecayState {
       finished: AnimatedValue<number>;


### PR DESCRIPTION
Self explanatory, Typescript will not build right now:

```
node_modules/react-native-reanimated/react-native-reanimated.d.ts:214:23 - error TS2315: Type 'MultiOperator' is not generic.

214     export const and: MultiOperator<0 | 1>;
                          ~~~~~~~~~~~~~~~~~~~~

node_modules/react-native-reanimated/react-native-reanimated.d.ts:215:22 - error TS2315: Type 'MultiOperator' is not generic.

215     export const or: MultiOperator<0 | 1>;
                         ~~~~~~~~~~~~~~~~~~~~


Found 2 errors.
```