### PR TITLE
Fix: jest mock should use Animated.ScrollView

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -9,7 +9,7 @@
  */
 
 const React = require('react');
-const { View, Text, Image, ScrollView } = require('react-native');
+const { View, Text, Image, Animated } = require('react-native');
 
 const NOOP = () => undefined;
 
@@ -32,7 +32,7 @@ module.exports = {
     View,
     Text,
     Image,
-    ScrollView,
+    ScrollView: Animated.ScrollView,
     Code,
 
     Clock: NOOP,


### PR DESCRIPTION
Ran into the issue here:
https://github.com/react-native-community/react-native-tab-view/issues/845

This is because `ScrollView` doesn't have `.getNode()` but `Animated.ScrollView` does. 

This change fixes the error. I think this is the correct fix.

cc @simonbuerger