### PR TITLE
Fix: Support optional string style types

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -153,7 +153,7 @@ declare module 'react-native-reanimated' {
               | S[K]
               | AnimatedNode<
                   // allow `number` where `string` normally is to support colors
-                  S[K] extends string ? S[K] | number : S[K]
+                  S[K] extends (string | undefined) ? S[K] | number : S[K]
                 >)
     };
 


### PR DESCRIPTION
It looks like because all style properties are optional, they're failing the conditional type in `AnimateStyle`, because `string | undefined` does not `extend string`.