### PR TITLE
doc: fix broken code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,13 +664,14 @@ Works the same way as with the original `Animated` library.
 Returns a callable function node that can be used to define expressions that can be called from other nodes. 
 
 Example:
-´´´js
+
+```js
 // Global constant
 const myProc = proc((a, b) => multiply(a,b));
 
 // In your component
 const style = { width: proc(10, 10 )};
-´´´
+```
 
 A proc node should be declared as a global constant in your code and not recreated from inside components.
 


### PR DESCRIPTION
fixed broken code block at README.md by replacing "´" (backtick?) to "`"