### PR TITLE
add event type to event mapping

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -251,9 +251,12 @@ declare module 'react-native-reanimated' {
     export function clockRunning(clock: AnimatedClock): AnimatedNode<0 | 1>;
     // the return type for `event` is a lie, but it's the same lie that
     // react-native makes within Animated
-    export function event(
-      argMapping: ReadonlyArray<Mapping>,
-      config?: {},
+    type EventArgFunc<T> = (arg: T) => Node<number>;
+    type EventMapping<T> = T extends object ? { [K in keyof T]?: EventMapping<T[K]> | EventArgFunc<T[K]> } : Adaptable<T> | EventArgFunc<T>;
+    type EventMappingArray<T> = T extends Array<any> ? { [I in keyof T]: EventMapping<T[I]> } : [EventMapping<T>]
+    export function event<T>(
+        argMapping: T extends never ? ReadonlyArray<Mapping> : Readonly<EventMappingArray<T>>,
+        config?: {},
     ): (...args: any[]) => void;
 
     // derived operations


### PR DESCRIPTION
## TypeScript

### Motivation
Making `event` easier to use by adding event type args.
Followed [spec](https://github.com/kmagiera/react-native-reanimated#event-handling-with-reanimated-nodes).


### Example
#### Code
```ts
import Animated from 'react-native-reanimated';
import { PanGestureHandler, PinchGestureHandler, RectButton, NativeViewGestureHandler, State, TapGestureHandlerStateChangeEvent, TapGestureHandler, LongPressGestureHandler, LongPressGestureHandlerStateChangeEvent, PanGestureHandlerGestureEvent, PinchGestureHandlerGestureEvent } from 'react-native-gesture-handler';

const {
    event,
    cond,
    eq,
    set
} = Animated

const value = new Animated.Value(0);

// in case an event has multiple args
event<[LongPressGestureHandlerStateChangeEvent, PanGestureHandlerGestureEvent]>([
    {
        nativeEvent: {
            state: (state) => cond(eq(state, State.ACTIVE), set(value, 1)),
            absoluteX: (a) => set(value, a),
            oldState: (v) => set(value, v),
            absoluteY: value
        }
    },
    { nativeEvent: ({ state, translationX, numberOfPointers }) => set(value, translationX) }
]);

// in case an event has only one arg
event<PinchGestureHandlerGestureEvent>([
    {
        nativeEvent: {
            state: (state) => cond(eq(state, State.ACTIVE), set(value, 1)),
            scale: value,
            absoluteX: (a) => set(value, a),      //   <- marked properly as an ERROR
            
        }
    }
]);

```
#### Screen Cast
![RNR](https://user-images.githubusercontent.com/34343793/64904358-83d82400-d6d1-11e9-9f61-7e25f4a09c63.jpg)
