### PR TITLE
Add createAnimatedComponent to mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -98,6 +98,7 @@ module.exports = {
     spring: NOOP,
 
     useCode: NOOP,
+    createAnimatedComponent: Component => Component,
   },
 
   Easing: {


### PR DESCRIPTION
### Goal

Following https://github.com/kmagiera/react-native-reanimated/issues/355 , `createAnimatedComponent` is not present in `mock.js` file and makes jest test crashes.

### Issue Example
![image](https://user-images.githubusercontent.com/26744253/65080673-262e2b00-d9a2-11e9-8b95-9c6ab5832511.png)
