### PR TITLE
Change drop procedure to rely on events instead of callbacks.

### DIFF
--- a/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -280,7 +280,11 @@ public class NodesManager implements EventDispatcherListener {
   }
 
   public void dropNode(int tag) {
-    mAnimatedNodes.remove(tag);
+    Node node = mAnimatedNodes.get(tag);
+    if (node != null) {
+      node.onDrop();
+      mAnimatedNodes.remove(tag);
+    }
   }
 
   public void connectNodes(int parentID, int childID) {

--- a/android/src/main/java/com/swmansion/reanimated/nodes/Node.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/Node.java
@@ -100,6 +100,9 @@ public abstract class Node {
     markUpdated();
   }
 
+  public void onDrop() {
+  }
+
   private static void findAndUpdateNodes(Node node, Set<Node> visitedNodes, Stack<FinalNode> finalNodes) {
     if (visitedNodes.contains(node)) {
       return;

--- a/android/src/main/java/com/swmansion/reanimated/nodes/ValueNode.java
+++ b/android/src/main/java/com/swmansion/reanimated/nodes/ValueNode.java
@@ -1,7 +1,9 @@
 package com.swmansion.reanimated.nodes;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.bridge.WritableMap;
 import com.swmansion.reanimated.NodesManager;
 
 import javax.annotation.Nullable;
@@ -36,5 +38,19 @@ public class ValueNode extends Node {
   @Override
   protected Object evaluate() {
     return mValue;
+  }
+
+  @Override
+  public void onDrop() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("id", mNodeID);
+   if (mValue instanceof String) {
+      eventData.putString("value", (String) mValue);
+    } else if (mValue instanceof Double) {
+      eventData.putDouble("value", (Double) mValue);
+    } else {
+      eventData.putNull("value");
+    }
+    mNodesManager.sendEvent("onReanimatedValueDropped", eventData);
   }
 }

--- a/ios/Nodes/REANode.h
+++ b/ios/Nodes/REANode.h
@@ -35,5 +35,6 @@ typedef NSNumber* REANodeID;
 
 - (void)dangerouslyRescheduleEvaluate;
 - (void)forceUpdateMemoizedValue:(id)value;
+- (void)drop;
 
 @end

--- a/ios/Nodes/REANode.m
+++ b/ios/Nodes/REANode.m
@@ -65,6 +65,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   return 0;
 }
 
+- (void)drop
+{
+  // no-op
+}
+
 - (id)value
 {
   if (![_lastLoopID objectForKey:_updateContext.callID] || [[_lastLoopID objectForKey:_updateContext.callID] longValue] < [_updateContext.loopID longValue]) {

--- a/ios/Nodes/REAValueNode.m
+++ b/ios/Nodes/REAValueNode.m
@@ -1,4 +1,6 @@
 #import "REAValueNode.h"
+#import "REANodesManager.h"
+#import "REAModule.h"
 
 @implementation REAValueNode {
   NSNumber *_value;
@@ -22,6 +24,18 @@
 - (id)evaluate
 {
   return _value;
+}
+
+- (void)drop
+{
+  NSObject *value = self.value;
+  if (!value) {
+    value = [NSNull null];
+  }
+
+  [self.nodesManager.reanimatedModule
+   sendEventWithName:@"onReanimatedValueDropped"
+   body:@{@"id": self.nodeID, @"value": value }];
 }
 
 @end

--- a/ios/REAModule.m
+++ b/ios/REAModule.m
@@ -167,7 +167,7 @@ RCT_EXPORT_METHOD(configureProps:(nonnull NSArray<NSString *> *)nativeProps
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"onReanimatedCall", @"onReanimatedPropsChange"];
+  return @[@"onReanimatedCall", @"onReanimatedPropsChange", @"onReanimatedValueDropped"];
 }
 
 - (void)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event

--- a/ios/REANodesManager.m
+++ b/ios/REANodesManager.m
@@ -258,6 +258,7 @@
 {
   REANode *node = _nodes[nodeID];
   if (node) {
+    [node drop];
     [_nodes removeObjectForKey:nodeID];
   }
 }


### PR DESCRIPTION
Here we change the way we handled nodes dropped on the native side. Since we don't know at the point of ropping a native node if it is going to be kept on the javascript side and reused later on, we have to copy the last seen value on the native side to be used later in case the node gets recreated on the native side. Previously we've been using getValue call. But because of an excessive amount of RN callback's that this way would produce in some cases we had to switch to using events instead (RN 61 added a check for a large number of callbacks being registered).

In order to test it I recommend checking "Imperative set value / toggle visibility" example app. There we can change the value of a node that exists on native and then detach component causing the node to be dropped from native but retained in javascript. Then we can render back the component and expect the reatached node to have the updated value.