### PR TITLE
Optimize constant nodes creation and cleanup

### DIFF
--- a/src/core/AnimatedBlock.js
+++ b/src/core/AnimatedBlock.js
@@ -31,7 +31,9 @@ function nodify(v) {
     return v.__val;
   }
   // TODO: cache some typical static values (e.g. 0, 1, -1)
-  return v instanceof AnimatedNode ? v : new InternalAnimatedValue(v);
+  return v instanceof AnimatedNode
+    ? v
+    : InternalAnimatedValue.valueForConstant(v);
 }
 
 export function adapt(v) {

--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -14,7 +14,7 @@ function initializeConstantValues() {
   if (CONSTANT_VALUES.size != 0) {
     return;
   }
-  [0, -1, 1].forEach(v =>
+  [0, -1, 1, -2, 2].forEach(v =>
     CONSTANT_VALUES.set(v, new InternalAnimatedValue(v, true))
   );
 }

--- a/src/core/InternalAnimatedValue.js
+++ b/src/core/InternalAnimatedValue.js
@@ -8,22 +8,43 @@ function sanitizeValue(value) {
     : Number(value);
 }
 
+const CONSTANT_VALUES = new Map();
+
+function initializeConstantValues() {
+  if (CONSTANT_VALUES.size != 0) {
+    return;
+  }
+  [0, -1, 1].forEach(v =>
+    CONSTANT_VALUES.set(v, new InternalAnimatedValue(v, true))
+  );
+}
+
 /**
  * This class has been made internal in order to omit dependencies' cycles which
  * were caused by imperative setValue and interpolate – they are currently exposed with AnimatedValue.js
  */
 export default class InternalAnimatedValue extends AnimatedNode {
-  constructor(value) {
+  static valueForConstant(number) {
+    initializeConstantValues();
+    return (
+      CONSTANT_VALUES.get(number) || new InternalAnimatedValue(number, true)
+    );
+  }
+
+  constructor(value, constant = false) {
     super({ type: 'value', value: sanitizeValue(value) });
     this._startingValue = this._value = value;
     this._animation = null;
+    this._constant = constant;
   }
 
   __detach() {
-    ReanimatedModule.getValue(
-      this.__nodeID,
-      val => (this.__nodeConfig.value = val)
-    );
+    if (!this._constant) {
+      ReanimatedModule.getValue(
+        this.__nodeID,
+        val => (this.__nodeConfig.value = val)
+      );
+    }
     this.__detachAnimation(this._animation);
     super.__detach();
   }


### PR DESCRIPTION
This PR optimizes the way we create and cleanup value nodes.

When adapting constants (e.g. when doing `interpolate({ inputRange: [0,1]})` we generate new nodes for start and end of the range) we've been creating new animated value nodes. This kind of nodes can never be updated on the native side and hence there is no need to send its final value back to JS when they get detached.

On top of there there are several constant values that are frequently used across the library and product code with reanimated. Those can only be instantiated once and reused in all the places. That list includes `0`, `1` and `-1` for now.

These two changes reduce the number of nodes instantiated by one third on `colors/index.js` example (from 88 down to 57) and reduce the number of nodes we call `getValue` for by 94% (from 88 down to 5).