### PR TITLE
Update android Example project build.gradle to build with RN 0.61

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 28
-        supportLibVersion = "28.0.0"
     }
     repositories {
         jcenter()


### PR DESCRIPTION
Ran into the following error when building on android with RN 0.61.1:

```
* What went wrong:
A problem occurred evaluating project ':react-native-reanimated'.
> Cannot get property 'supportLibVersion' on extra properties extension as it does not exist
```