### PR TITLE
🎣Allow to pass a callback as parameter of useCode()

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,16 +224,18 @@ block([
 
 The `useCode` hook acts as an alternative to the `Animated.Code` component.
 ```js
-Animated.useCode(node, deps)
+Animated.useCode(() => node, deps)
 ```
 It's passed an animated node and an array of dependencies, and updates that node both when the component mounts and every time a value in that array changes. It does nothing on versions of React Native that don't support hooks (<0.59).
 ```js
 const [offset, setOffset] = React.useState(20);
 Animated.useCode(
-  set(transX1, add(_transX, offset)),
+  () => set(transX1, add(_transX, offset)),
   [offset]
 );
 ```
+
+We recommend to use `useCode()` with the `react-hooks/exhaustive-deps` [eslint rule](https://www.npmjs.com/package/eslint-plugin-react-hooks).
 
 ## Event handling with reanimated nodes
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -329,7 +329,7 @@ declare module 'react-native-reanimated' {
 
     // hooks
     export function useCode(
-      exec: AnimatedNode<number>,
+      exec: AnimatedNode<number> | (() => AnimatedNode<number>),
       deps: Array<any>,
     ): void
 

--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -329,7 +329,7 @@ declare module 'react-native-reanimated' {
 
     // hooks
     export function useCode(
-      exec: AnimatedNode<number> | (() => AnimatedNode<number>),
+      exec: () => AnimatedNode<number>,
       deps: Array<any>,
     ): void
 

--- a/src/derived/useCode.js
+++ b/src/derived/useCode.js
@@ -4,7 +4,7 @@ import { always } from '../base';
 function useCode(exec, deps) {
   if (typeof React.useEffect === 'function') {
     React.useEffect(() => {
-      const animatedAlways = always(exec);
+      const animatedAlways = always(typeof React.useEffect === 'function' ? exec() : exec);
       animatedAlways.__attach();
       return () => {
         animatedAlways.__detach();

--- a/src/derived/useCode.js
+++ b/src/derived/useCode.js
@@ -4,6 +4,11 @@ import { always } from '../base';
 function useCode(exec, deps) {
   if (typeof React.useEffect === 'function') {
     React.useEffect(() => {
+      if (typeof exec !== 'function') {
+        console.warn(
+          'useCode() first argument should be a function that returns an animation node.'
+        );
+      }
       const animatedAlways = always(typeof exec === 'function' ? exec() : exec);
       animatedAlways.__attach();
       return () => {

--- a/src/derived/useCode.js
+++ b/src/derived/useCode.js
@@ -4,7 +4,7 @@ import { always } from '../base';
 function useCode(exec, deps) {
   if (typeof React.useEffect === 'function') {
     React.useEffect(() => {
-      const animatedAlways = always(typeof React.useEffect === 'function' ? exec() : exec);
+      const animatedAlways = always(typeof exec === 'function' ? exec() : exec);
       animatedAlways.__attach();
       return () => {
         animatedAlways.__detach();


### PR DESCRIPTION
fixes #343 

This can enable us to save some unnecessary node creation but more importantly, it will enable us to benefit from the Exhaustive Deps eslint rule. This rule expect a callback as first parameter: https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js#L64
This rule is incredibly useful to avoid bugs when using hooks that have dependencies.

@osdnk what do you think?