### PR TITLE
Add Jest doc to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,14 @@ Then run `react-native run-android` or `react-native run-ios` (depending on whic
 
 You will need to have an Android or iOS device or emulator connected as well as `react-native-cli` package installed globally.
 
+## Jest
+
+In order to use `react-native-reanimated` with Jest, you need to add the following mock implementation at the top of your test:
+
+```js
+jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
+```
+
 ## License
 
 React native reanimated library is licensed under [The MIT License](LICENSE).


### PR DESCRIPTION
Following https://github.com/kmagiera/react-native-reanimated/issues/355#issuecomment-533455387 it's true that there is no easily accessible documentation about how to set up Jest tests with reanimated.

@kmagiera Are you fine to have it in the README or would you like to see it somewhere else ?