### PR TITLE
Fix invalid url in readme.md (example in event handling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Animated.useCode(
 `react-native-reanimated`'s new syntax is possible to be used with `Animated.event`. Instead of providing only a mapping from event fields to animated nodes, it is allowed to write a function that takes reanimated values map as an input and return a block (or any other reanimated function) that will be then used to handle the event.
 
 This syntax allows for providing some post-processing for the event data that does not fit well as a dependency of other nodes we connect to `Animated.View` component props.
-[See example](https://github.com/kmagiera/react-native-reanimated/blob/master/Example/movable/index.js)
+[See example](https://github.com/kmagiera/react-native-reanimated/blob/master/Example/PanRotateAndZoom/index.js)
 ```js
 this.onGestureEvent = event([
   {


### PR DESCRIPTION
Following [#111](https://github.com/kmagiera/react-native-reanimated/pull/111), `movable` example was disappeared. But [readme.md](https://github.com/kmagiera/react-native-reanimated/blob/master/README.md#event-handling-with-reanimated-nodes) points to deprecated example link.