### PR TITLE
💄Export AnimateProps & AnimateStyle

### DIFF
--- a/react-native-reanimated.d.ts
+++ b/react-native-reanimated.d.ts
@@ -145,9 +145,9 @@ declare module 'react-native-reanimated' {
 
     export const SpringUtils: SpringUtils
 
-    type AnimatedTransform = { [P in keyof TransformsStyle["transform"]]: Animated.Adaptable<TransformsStyle["transform"][P]> };
+    export type AnimatedTransform = { [P in keyof TransformsStyle["transform"]]: Animated.Adaptable<TransformsStyle["transform"][P]> };
 
-    type AnimateStyle<S extends object> = {
+    export type AnimateStyle<S extends object> = {
       [K in keyof S]: K extends 'transform' ? AnimatedTransform : (S[K] extends ReadonlyArray<any>
         ? ReadonlyArray<AnimateStyle<S[K][0]>>
         : S[K] extends object
@@ -160,7 +160,7 @@ declare module 'react-native-reanimated' {
                 >)
     };
 
-    type AnimateProps<
+    export type AnimateProps<
       S extends object,
       P extends {
         style?: StyleProp<S>;


### PR DESCRIPTION
Exporting these types can be useful for component definition.
For instance:

```ts
interface FlexibleCardProps extends CardProps {
  style?: Animated.AnimateStyle<ImageStyle>;
}

export const FlexibleCard = ({ card, style }: FlexibleCardProps) => (
  <Animated.Image
    style={[styles.flexibleContainer, style]}
    source={card.source}
  />
);
```
```