### PR TITLE
fix: mock.js NOOP to allow for "new" constructor call

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -101,6 +101,8 @@ module.exports = {
     timing: NOOP,
     spring: NOOP,
 
+    proc: () => NOOP,
+
     useCode: NOOP,
     createAnimatedComponent: Component => Component,
   },

--- a/mock.js
+++ b/mock.js
@@ -37,7 +37,11 @@ module.exports = {
 
     Clock: NOOP,
     Node: NOOP,
-    Value: NOOP,
+    Value: function() {
+      return {
+        setValue: NOOP,
+      };
+    },
 
     Extrapolate: {
       EXTEND: 'extend',

--- a/mock.js
+++ b/mock.js
@@ -11,7 +11,7 @@
 const React = require('react');
 const { View, Text, Image, Animated } = require('react-native');
 
-const NOOP = () => undefined;
+function NOOP() {}
 
 class Code extends React.Component {
   render() {


### PR DESCRIPTION
i'm getting errors in my tests from this mock as the `new Value(0)` call throws for arrow functions, this seems to work when i updated my mock.js in node_modules. 